### PR TITLE
Don't error out if PlanePlacementStrategy ray intersect fails

### DIFF
--- a/addons/asset_placer/placement/asset_placement_strategy.gd
+++ b/addons/asset_placer/placement/asset_placement_strategy.gd
@@ -4,12 +4,13 @@ class_name AssetPlacementStrategy
 class CollisionHit:
 	var position: Vector3
 	var normal: Vector3
-	
+
 	func _init(position: Vector3, normal: Vector3):
 		self.position = position
 		self.normal = normal
 
-	static var ZERO := CollisionHit.new(Vector3.ZERO, Vector3.UP)
+	static func zero() -> CollisionHit:
+		return CollisionHit.new(Vector3.ZERO, Vector3.UP)
 
 func get_placement_point(camera: Camera3D, mouse_position: Vector2) -> CollisionHit:
-	return CollisionHit.ZERO
+	return CollisionHit.zero()

--- a/addons/asset_placer/placement/plane_placement_strategy.gd
+++ b/addons/asset_placer/placement/plane_placement_strategy.gd
@@ -6,8 +6,8 @@ var plane_options: PlaneOptions
 
 func _init(plane_options: PlaneOptions):
 	self.plane_options = plane_options
-	
-	
+
+
 func get_placement_point(camera: Camera3D, mouse_position: Vector2) -> AssetPlacementStrategy.CollisionHit:
 	var ray_origin = camera.project_ray_origin(mouse_position)
 	var	ray_dir = camera.project_ray_normal(mouse_position)
@@ -16,5 +16,5 @@ func get_placement_point(camera: Camera3D, mouse_position: Vector2) -> AssetPlac
 	if intersection:
 		return AssetPlacementStrategy.CollisionHit.new(intersection, plane.normal)
 	else:
-		return AssetPlacementStrategy.CollisionHit.ZERO
-	
+		return AssetPlacementStrategy.CollisionHit.zero()
+

--- a/addons/asset_placer/placement/surface_asset_placement_strategy.gd
+++ b/addons/asset_placer/placement/surface_asset_placement_strategy.gd
@@ -16,10 +16,9 @@ func get_placement_point(camera: Camera3D, mouse_position: Vector2) -> Collision
 	params.exclude = exclude_rids
 	params.to = ray_origin + ray_dir * 1000
 	var result = space_state.intersect_ray(params)
+	if not result.has('position') or not result.has('normal'):
+		return AssetPlacementStrategy.CollisionHit.zero()
+
 	var position: Vector3 = result.position
 	var normal: Vector3 = result.normal
-	if position and normal:
-		return AssetPlacementStrategy.CollisionHit.new(position, normal)
-	else:
-		return AssetPlacementStrategy.CollisionHit.ZERO
-	
+	return AssetPlacementStrategy.CollisionHit.new(position, normal)


### PR DESCRIPTION
# Pull Request

## Description

If the `PlanePlacementStrategy` plane intersection ray fails the output is flooded with errors. The existing codebase attempted to account for this but didn't do so correctly. This PR corrects the checks.

## Related Issue

Fixes #20

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please specify):

## How Has This Been Tested?

Followed the steps to replicate in the linked issue.

## Additional Context

This PR fixes the errors in the way the original code attempted to, however the resulting functionality isn't ideal from a user perspective. The asset sits at position 0,0,0 and doesn't follow the mouse with no indication as to why. Clicking will create an asset in the scene tree and hologram another directly over the top of it so it appears like nothing has happened. 


https://github.com/user-attachments/assets/68de0d92-3118-4482-8d2e-be13f04bf49f


A future UX pass will be needed here as the current functionality is very confusing.


