### PR TITLE
Add disabled 'All' collection when no collections defined

### DIFF
--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -128,7 +128,7 @@ placeholder_text = "Filter assets by name"
 [node name="FilterButton" type="Button" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "Edit"
+tooltip_text = "Filter by Collection"
 icon = SubResource("Texture2D_yvyyx")
 
 [node name="FiltersLabel" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer/FilterButton"]

--- a/addons/asset_placer/ui/collection_picker/collection_picker.gd
+++ b/addons/asset_placer/ui/collection_picker/collection_picker.gd
@@ -12,21 +12,27 @@ func _ready():
 	hide_on_checkable_item_selection = false
 	presenter.show_collections.connect(show_collections)
 	presenter.ready()
-	
+
 
 func show_collections(collections: Array[AssetCollection]):
+	if collections.size() == 0:
+		add_check_item("All")
+		set_item_checked(0, true)
+		set_item_icon(0, make_circle_icon(16, Color.WHITE))
+		set_item_disabled(0, true)
+
 	for i in collections.size():
 		var collection_name = collections[i].name
 		var selected = pre_selected.any(func(c): return c.name == collection_name)
 		add_check_item(collection_name)
 		set_item_checked(i, selected)
 		set_item_icon(i, make_circle_icon(16, collections[i].backgroundColor))
-	
+
 	index_pressed.connect(func(index):
 		toggle_item_checked(index)
 		collection_selected.emit(collections[index], is_item_checked(index))
 	)
-	
+
 func make_circle_icon(radius: int, color: Color) -> Texture2D:
 	var size = radius * 2
 	var img := Image.create(size, size, false, Image.FORMAT_RGBA8)


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a disabled, always checked 'All' collection if the 'Filter by Collection' button is clicked with no collections defined.

<img width="782" height="311" alt="image" src="https://github.com/user-attachments/assets/16098586-3803-40b0-9ad7-30b63ff68208" />

The PR also improves the tooltip of the button from 'Edit' to 'Filter by Collection'.


## Related Issue

Fixes #23

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please specify):

## How Has This Been Tested?

Removed all collections, clicked the button. Added a collection, clicked the button again.

## Additional Context

I considered disabling the button and updating the tooltip if no collections were defined but adding the fake 'All' collection was the simplest way to solve the attached issue due to the way the button works and how it has no knowledge of what or how many collections exist.
