### PR TITLE
fix rotation using 0.1 rad instead of deg

### DIFF
--- a/addons/asset_placer/asset_placer.gd
+++ b/addons/asset_placer/asset_placer.gd
@@ -94,7 +94,7 @@ func transform_preview(mode: AssetPlacerPresenter.TransformMode, axis: Vector3, 
 			preview_node.scale = new_scale
 			return true
 		AssetPlacerPresenter.TransformMode.Rotate:
-			preview_node.rotate(axis.normalized() * direction, preview_transform_step)
+			preview_node.rotate(axis.normalized() * direction, deg_to_rad(5)) # Can be replaced with deg_to_rad(preview_transform_step) however 0.1 deg is realy low. 
 			return true
 			
 		AssetPlacerPresenter.TransformMode.Move:

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn
@@ -11,7 +11,7 @@ script = ExtResource("2_o45xf")
 icon_name = &"Node3D"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
-[sub_resource type="Texture2D" id="Texture2D_5hqbk"]
+[sub_resource type="Texture2D" id="Texture2D_o45xf"]
 resource_local_to_scene = false
 resource_name = ""
 script = ExtResource("2_o45xf")
@@ -88,7 +88,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 text = "No parent selected"
-icon = SubResource("Texture2D_5hqbk")
+icon = SubResource("Texture2D_o45xf")
 alignment = 0
 
 [node name="PlacementMode" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer"]


### PR DESCRIPTION
# Pull Request

## Description

The rotation was using 0.1 rad which is about 5.73 deg. 
I changed it to a hard coded 5 deg for now since rotating by 0.1 deg is exhausting.


## Related Issue

Fixes #39 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please specify):

## How Has This Been Tested?

Tested and working using Godot 4.5-stable and Godot 4.5-rc1

## Additional Context

Maybe the rotation amount should be made configurable in the future. Or something like normal is 5 deg. holding shift changes to 10 deg, hodling control changes to 1 deg.
