### PR TITLE
fix: Change scene to use correct icon

### DIFF
--- a/addons/asset_placer/ui/asset_collections_window/components/collection_list_item.tscn
+++ b/addons/asset_placer/ui/asset_collections_window/components/collection_list_item.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dmicn3kmr620j" path="res://addons/asset_placer/utils/system_icon.gd" id="1_q0bvl"]
 [ext_resource type="Script" uid="uid://bf5fmwafbhhb0" path="res://addons/asset_placer/ui/asset_collections_window/components/collection_list_item.gd" id="1_xjg5v"]
-[ext_resource type="Texture2D" uid="uid://btqtv2stkxtdk" path="res://docs/logo.png" id="2_ligpx"]
+[ext_resource type="Texture2D" uid="uid://be61c5ff55gfo" path="res://addons/asset_placer/icon.png" id="2_ligpx"]
 
 [sub_resource type="Texture2D" id="Texture2D_xjg5v"]
 resource_local_to_scene = false


### PR DESCRIPTION
# Pull Request

## Description

Fixes #49 

Previously the plugin would try to open an icon outside the exported folder, and it would print an error in the Output panel.
This fix was intended to be implemented in #35, but it was forgotten. 


## Related Issue
#35 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please specify):

## How Has This Been Tested?
Ran on Godot 4.5.stable

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally in Godot
- [x] I have updated documentation if needed
- [x] I have added relevant tests if applicable
