### PR TITLE
Fix: Change path concatenation to use path_join

### DIFF
--- a/addons/asset_placer/data/synchronizer.gd
+++ b/addons/asset_placer/data/synchronizer.gd
@@ -66,13 +66,13 @@ func add_assets_from_folder(folder_path: String, recursive: bool):
 	var tags : Array[int] = []
 	for file in dir.get_files():
 		_scanned += 1
-		var path = folder_path + "/" + file
+		var path = folder_path.path_join(file)
 		if asset_repository.add_asset(path, tags, folder_path):
 			_added += 1
 		
 	if recursive:
 		for sub_dir in dir.get_directories():
-			var path: String = folder_path + "/" + sub_dir
+			var path: String = folder_path.path_join(sub_dir)
 			add_assets_from_folder(path, true)
 
 

--- a/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
@@ -41,7 +41,7 @@ func add_asset_folder(path: String):
 	folder_repository.add(path)
 	var dir_access = DirAccess.open(path)
 	for file in dir_access.get_files():
-		add_asset(path + file, path)
+		add_asset(path.path_join(file), path)
 
 func on_query_change(query: String):
 	self._current_query = query


### PR DESCRIPTION
# Pull Request

## Description
add_asset_folder would previously occasionaly make an invalid file path, now uses safer path_join.

More precisely when adding a folder with assets in the root folder, their paths would be stored without an "/" an would throw an error on next load. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please specify):


