### PR TITLE
fix: guarantee new collection id will be unique

### DIFF
--- a/addons/asset_placer/data/asset_collection_repository.gd
+++ b/addons/asset_placer/data/asset_collection_repository.gd
@@ -35,9 +35,11 @@ func update_collection(collection: AssetCollection):
 func add_collection(name: String, color: Color):
 	var lib = _data_source.get_library()
 	_current_highest_id += 1
-	assert(_current_highest_id > lib.get_highest_id(),
-		"Cannot create collection with id %s as it already exists." % _current_highest_id)
-	var collection: = AssetCollection.new(name, color, _current_highest_id)
+	assert(
+		_current_highest_id > lib.get_highest_id(),
+		"Cannot create collection with id %s as it already exists." % _current_highest_id
+	)
+	var collection := AssetCollection.new(name, color, _current_highest_id)
 	lib.collections.append(collection)
 	_data_source.save_libray(lib)
 	collections_changed.emit()

--- a/addons/asset_placer/data/asset_library.gd
+++ b/addons/asset_placer/data/asset_library.gd
@@ -25,7 +25,7 @@ func index_of_asset(asset: AssetResource):
 
 
 func get_highest_id() -> int:
-	var highest: = 0
+	var highest := 0
 	for collection in collections:
 		if collection.id > highest:
 			highest = collection.id


### PR DESCRIPTION
Fixes #48 

This PR replaces the old way of adding collection ID, which would incorrectly read a value from ProjectSettings.

New collection id will now always be higher than the highest pre-existing id.


## Type of Change

- [x] Bug fix

## How Has This Been Tested?
I created new collections in a new Project, then restarted and created more. All collection ids were unique in the asset_library file. 


