### PR TITLE
feat: add support for blend files

### DIFF
--- a/addons/asset_placer/data/assets_repository.gd
+++ b/addons/asset_placer/data/assets_repository.gd
@@ -64,5 +64,5 @@ func add_asset(scene_path: String, tags: Array[int] = [], folder_path: String = 
 
 func is_file_supported(file: String) -> bool:
 	var extension = file.get_extension()
-	var supported_extensions = ["tscn", "glb", "fbx", "obj", "gltf"]
+	var supported_extensions = ["tscn", "glb", "fbx", "obj", "gltf", "blend"]
 	return extension in supported_extensions


### PR DESCRIPTION
resolves #70 

Plugin can now manage and place blend files.

## Type of Change
- [x] New feature

## How Has This Been Tested?
Adding a blend file to a pre-existing folder and syncing works fine, it is detected. Placing it also works like any other scene file. Trying to place a an unimported blender file with blender imports disabled, prints a generic error "Invalid Asset", i assume this is acceptable behaviour. 

