### PR TITLE
fix: make Terrain3D placement snap correctly

### DIFF
--- a/addons/asset_placer/asset_placer.gd
+++ b/addons/asset_placer/asset_placer.gd
@@ -74,6 +74,10 @@ func move_preview(mouse_position: Vector2, camera: Camera3D) -> bool:
 			normal = hit.normal
 
 		var snapped_pos = _snap_position(hit.position, normal)
+		# Use snapped position to get correct height of terrain.
+		if _strategy is Terrain3DAssetPlacementStrategy:
+			snapped_pos.y = _strategy.terrain_3d_node.data.get_height(snapped_pos)
+
 		var forward_hint = preview_node.global_transform.basis.z
 
 		var new_basis = get_safe_basis(normal, forward_hint).scaled(preview_node.scale)

--- a/addons/asset_placer/placement/terrain_3d_placement_strategy.gd
+++ b/addons/asset_placer/placement/terrain_3d_placement_strategy.gd
@@ -13,7 +13,8 @@ func get_placement_point(camera: Camera3D, mouse_position: Vector2) -> Collision
 		var from := camera.project_ray_origin(mouse_position)
 		var to := from + camera.project_ray_normal(mouse_position) * 1000
 		var direction = (to - from).normalized()
-		var hit_position: Vector3 = terrain_3d_node.get_intersection(from, direction, false)
+		# Using cpu-mode is too inaccurate for most placing.
+		var hit_position: Vector3 = terrain_3d_node.get_intersection(from, direction, true)
 		if hit_position != Vector3.INF:
 			var data = terrain_3d_node.data
 			var normal = data.get_normal(hit_position)


### PR DESCRIPTION
# Pull Request

## Description

Previously, trying to place an asset on a Terrain3D node would not snap the asset to the surface of the Terrain3D. This was because the Terrain3D algorithm used raymarching, which caused instability when using certain camera angles. Using the gpu algorithm fixes this.

## Type of Change

- [x] Bug fix

### Previous behaviour:

[Screencast from 2026-02-25 00-22-32.webm](https://github.com/user-attachments/assets/b5f6a2e8-75d5-4543-8c54-8c632104a663)

### New behaviour:

[Screencast from 2026-02-25 00-50-53.webm](https://github.com/user-attachments/assets/df13e8cc-e1f7-45a3-bdaa-b600e4f6cb3e)
