### PR TITLE
feat: Add asset sort

### DIFF
--- a/addons/asset_placer/asset_placer_plugin.gd
+++ b/addons/asset_placer/asset_placer_plugin.gd
@@ -111,6 +111,7 @@ func _exit_tree():
 	overlay.queue_free()
 	_plane_preview.queue_free()
 
+	APEditorSettingsManager.free_settings()
 	AssetLibraryManager.free_library()
 
 	settings_repository.settings_changed.disconnect(_react_to_settings_change)
@@ -152,6 +153,8 @@ func _initialize_data_layer():
 	settings_repository = AssetPlacerSettingsRepository.new()
 	current_settings = settings_repository.get_settings()
 	settings_repository.settings_changed.connect(_react_to_settings_change)
+
+	APEditorSettingsManager.load_editor_settings()
 
 	# TODO load library file save path setting
 	var path := AssetLibraryParser.DEFAULT_SAVE_PATH

--- a/addons/asset_placer/asset_placer_presenter.gd
+++ b/addons/asset_placer/asset_placer_presenter.gd
@@ -318,6 +318,10 @@ func end_node_transform_mode():
 
 
 func on_asset_placed():
+	var es := APEditorSettingsManager.get_editor_settings()
+	if es:
+		es.update_asset_time_placed(_selected_asset.id)
+
 	if options.enable_random_placement:
 		var random = current_assets.pick_random()
 		select_asset(random)

--- a/addons/asset_placer/data/asset_library.gd
+++ b/addons/asset_placer/data/asset_library.gd
@@ -77,6 +77,9 @@ func remove_asset_by_id(asset_id: String):
 	assert(index != -1, "Cannot remove asset with id %s as it doesn't exist" % asset_id)
 
 	_assets.remove_at(index)
+	var es := APEditorSettingsManager.get_editor_settings()
+	if es:
+		es.remove_asset_time_placed(asset_id)
 	_queue_emit_assets_changed()
 
 

--- a/addons/asset_placer/data/asset_library_parser.gd
+++ b/addons/asset_placer/data/asset_library_parser.gd
@@ -95,7 +95,7 @@ static func save_library(library: AssetLibrary, save_path = DEFAULT_SAVE_PATH):
 				"tags": asset.tags,
 				"folder_path": asset.folder_path,
 				"primary_collection": asset.primary_collection,
-				"date_added": asset.date_added,
+				"date_added": asset.date_added
 			}
 		)
 

--- a/addons/asset_placer/data/asset_library_parser.gd
+++ b/addons/asset_placer/data/asset_library_parser.gd
@@ -48,7 +48,11 @@ static func load_library(load_path = DEFAULT_SAVE_PATH) -> AssetLibrary:
 		var p_collection: int = -1
 		if dict.has("primary_collection"):
 			p_collection = int(dict["primary_collection"])
-		var asset = AssetResource.new(id, asset_name, tags, folder_path, p_collection)
+
+		var date_added := 0.0
+		if dict.has("date_added"):
+			date_added = float(dict["date_added"])
+		var asset = AssetResource.new(id, asset_name, tags, folder_path, p_collection, date_added)
 		assets.append(asset)
 
 	for collection_dict in collections_dict:
@@ -90,7 +94,8 @@ static func save_library(library: AssetLibrary, save_path = DEFAULT_SAVE_PATH):
 				"id": asset.id,
 				"tags": asset.tags,
 				"folder_path": asset.folder_path,
-				"primary_collection": asset.primary_collection
+				"primary_collection": asset.primary_collection,
+				"date_added": asset.date_added,
 			}
 		)
 

--- a/addons/asset_placer/data/asset_placer_editor_settings.gd
+++ b/addons/asset_placer/data/asset_placer_editor_settings.gd
@@ -1,0 +1,26 @@
+@tool
+extends Resource
+class_name AssetPlacerEditorSettings
+
+## Resource for holding editor settings specific to a project.
+
+## Holds a AssetResource id as a key and a UNIX timestamp as value.
+@export_storage var _assets_time_placed : Dictionary[String, float] = {}
+
+
+func get_assets_time_placed() -> Dictionary[String, float]:
+	return _assets_time_placed
+
+
+func update_asset_time_placed(asset_id: String):
+	_assets_time_placed[asset_id] = Time.get_unix_time_from_system()
+	emit_changed()
+
+
+func remove_asset_time_placed(asset_id: String):
+	if _assets_time_placed.has(asset_id):
+		_assets_time_placed.erase(asset_id)
+
+
+func _emit_all_changed():
+	emit_changed()

--- a/addons/asset_placer/data/asset_placer_editor_settings.gd
+++ b/addons/asset_placer/data/asset_placer_editor_settings.gd
@@ -1,11 +1,11 @@
 @tool
-extends Resource
 class_name AssetPlacerEditorSettings
+extends Resource
 
 ## Resource for holding editor settings specific to a project.
 
 ## Holds a AssetResource id as a key and a UNIX timestamp as value.
-@export_storage var _assets_time_placed : Dictionary[String, float] = {}
+@export_storage var _assets_time_placed: Dictionary[String, float] = {}
 
 
 func get_assets_time_placed() -> Dictionary[String, float]:

--- a/addons/asset_placer/data/asset_placer_editor_settings.gd.uid
+++ b/addons/asset_placer/data/asset_placer_editor_settings.gd.uid
@@ -1,0 +1,1 @@
+uid://dehq113jkjqqa

--- a/addons/asset_placer/data/asset_placer_editor_settings_manager.gd
+++ b/addons/asset_placer/data/asset_placer_editor_settings_manager.gd
@@ -1,0 +1,90 @@
+@tool
+class_name APEditorSettingsManager
+extends RefCounted
+
+## Singleton class to manage a single active AssetPlacerEditorSettings
+
+const SAVE_PATH := "user://asset_placer_editor_settings.tres"
+
+## Time between settings change and save to disk in seconds.
+static var time_to_save: float = 1.0
+
+static var _editor_settings: AssetPlacerEditorSettings
+static var _save_timer: SceneTreeTimer
+
+
+static func get_editor_settings() -> AssetPlacerEditorSettings:
+	assert(
+		is_instance_valid(_editor_settings),
+		"Cannot get AssetPlacerEditorSettings when none is loaded."
+	)
+	return _editor_settings
+
+
+static func load_editor_settings(load_path := SAVE_PATH) -> void:
+	if is_instance_valid(_save_timer):
+		_save_editor_settings()
+
+	var new_editor_settings := AssetPlacerEditorSettings.new()
+	if ResourceLoader.exists(load_path, &"AssetPlacerEditorSettings"):
+		new_editor_settings = load(load_path)
+
+	var is_first_load := not is_instance_valid(_editor_settings)
+	if is_first_load:
+		_editor_settings = new_editor_settings
+		_connect_save()
+	else:
+		_disconnect_save()
+		_move_signal_connections(new_editor_settings)
+
+		_editor_settings = new_editor_settings
+		_editor_settings._emit_all_changed()
+
+		_connect_save()
+
+
+static func free_settings():
+	if is_instance_valid(_save_timer):
+		_save_editor_settings()
+
+	_move_signal_connections(null)
+	_editor_settings = null
+
+
+static func _save_editor_settings():
+	_save_timer.timeout.disconnect(_save_editor_settings)
+	_save_timer = null
+
+	assert(
+		is_instance_valid(_editor_settings),
+		"Cannot save AssetPlacerEditorSettings when none is loaded."
+	)
+	ResourceSaver.save(_editor_settings, SAVE_PATH)
+
+
+static func _queue_save():
+	if is_instance_valid(_save_timer):
+		_save_timer.time_left = time_to_save
+		return
+
+	var mainloop := Engine.get_main_loop()
+	assert(mainloop is SceneTree)
+
+	_save_timer = (mainloop as SceneTree).create_timer(time_to_save)
+	_save_timer.timeout.connect(_save_editor_settings)
+
+
+static func _move_signal_connections(other: AssetPlacerEditorSettings):
+	for _signal in _editor_settings.get_signal_list():
+		for connection in _editor_settings.get_signal_connection_list(_signal["name"]):
+			_editor_settings.disconnect(_signal["name"], connection["callable"])
+			if is_instance_valid(other):
+				other.connect(_signal["name"], connection["callable"])
+
+
+static func _connect_save():
+	_editor_settings.changed.connect(_queue_save)
+
+
+static func _disconnect_save():
+	_editor_settings.changed.disconnect(_queue_save)

--- a/addons/asset_placer/data/asset_placer_editor_settings_manager.gd.uid
+++ b/addons/asset_placer/data/asset_placer_editor_settings_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://dxy8ilv7fxywm

--- a/addons/asset_placer/data/asset_resource.gd
+++ b/addons/asset_placer/data/asset_resource.gd
@@ -6,6 +6,8 @@ var id: String
 var tags: Array[int]
 var folder_path: String
 var primary_collection: int = -1
+## UNIX timestamp of when the AssetResource was added to AssetLibrary.
+var date_added: float
 
 var _resource: Resource = null
 ## If _resource fails to load, don't try to load it anymore
@@ -22,13 +24,15 @@ func _init(
 	p_name: String,
 	p_tags: Array[int] = [],
 	p_folder_path: String = "",
-	p_primary_collection: int = -1
+	p_primary_collection: int = -1,
+	p_date_added: float = 0.0,
 ):
 	name = p_name
 	id = res_id
 	tags = p_tags
 	folder_path = p_folder_path
 	primary_collection = p_primary_collection
+	date_added = p_date_added
 
 
 func get_primary_collection() -> int:

--- a/addons/asset_placer/data/synchronizer.gd
+++ b/addons/asset_placer/data/synchronizer.gd
@@ -74,7 +74,9 @@ func add_assets_from_folder(folder: AssetFolder, override_path := ""):
 
 		var uid = ResourceIdCompat.path_to_uid(folder_path.path_join(file))
 		if not lib.has_asset_id(uid):
-			var asset := AssetResource.new(uid, file, [], folder_path)
+			var asset := AssetResource.new(
+				uid, file, [], folder_path, -1, Time.get_unix_time_from_system()
+			)
 			for rule in folder.get_rules():
 				asset = rule.do_after_asset_added(asset)
 			if lib.add_asset(asset):

--- a/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
@@ -59,7 +59,9 @@ func add_asset(path: String, folder_path: String):
 		existing.add_tags(tags)
 		_asset_library.update_asset(existing)
 	else:
-		var new_asset := AssetResource.new(id, path.get_file(), tags, folder_path)
+		var new_asset := AssetResource.new(
+			id, path.get_file(), tags, folder_path, -1, Time.get_unix_time_from_system()
+		)
 		_asset_library.add_asset(new_asset)
 
 

--- a/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
@@ -9,10 +9,12 @@ signal show_empty_view(type: EmptyType)
 enum EmptyType { Search, Collection, All, None }
 
 var synchronizer: Synchronize
+var is_sort_ascending := true
 
 var _active_collections: Array[AssetCollection] = []
 var _filtered_assets: Array[AssetResource] = []
 var _current_query: String
+var _current_sort_method: AssetSortBy.SortMethod
 
 var _asset_library: AssetLibrary:
 	get:
@@ -90,6 +92,11 @@ func toggle_collection_filter(collection: AssetCollection, enabled: bool):
 	_filter_by_collections_and_query()
 
 
+func on_sort_method_change(method: AssetSortBy.SortMethod):
+	_current_sort_method = method
+	_filter_by_collections_and_query()
+
+
 func _filter_by_collections_and_query():
 	var filtered: Array[AssetResource] = []
 	for asset in _asset_library.get_assets():
@@ -101,6 +108,7 @@ func _filter_by_collections_and_query():
 		if matches_query and belongs_to_collection:
 			filtered.push_back(asset)
 
+	filtered.sort_custom(AssetSortBy.get_sort_function(_current_sort_method, is_sort_ascending))
 	if filtered.is_empty():
 		if _active_collections.is_empty() && _current_query.is_empty():
 			show_empty_view.emit(EmptyType.All)

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
@@ -152,7 +152,6 @@ func set_selected_asset(asset: AssetResource):
 
 
 func flip_order():
-	ascending_order_button.pivot_offset = ascending_order_button.size / 2
 	ascending_order_button.scale.y *= -1
 	var text := "Sort by %s order." % ("ascending" if presenter.is_sort_ascending else "descending")
 	ascending_order_button.tooltip_text = text

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
@@ -31,6 +31,9 @@ signal asset_selected(asset: AssetResource)
 
 
 func _ready():
+	if is_part_of_edited_scene():
+		return
+
 	presenter.assets_loaded.connect(show_assets)
 	presenter.show_filter_info.connect(show_filter_info)
 	AssetPlacerPresenter._instance.asset_selected.connect(set_selected_asset)

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
@@ -46,7 +46,7 @@ func _ready():
 	presenter.on_ready()
 
 	for method in AssetSortBy.SortMethod.keys():
-		sort_button.add_item( method.capitalize(), AssetSortBy.SortMethod[method])
+		sort_button.add_item(method.capitalize(), AssetSortBy.SortMethod[method])
 
 	sort_button.selected = 0
 	sort_button.item_selected.connect(presenter.on_sort_method_change)

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.gd
@@ -17,6 +17,9 @@ signal asset_selected(asset: AssetResource)
 @onready var filter_button: Button = %FilterButton
 @onready var filters_label: Label = %FiltersLabel
 @onready var reload_button: Button = %ReloadButton
+@onready var sort_button: Button = %SortButton
+@onready var ascending_order_button: Button = %AscendingOrderButton
+
 @onready var progress_bar = %ProgressBar
 @onready var empty_content = %EmptyContent
 @onready var main_content = %MainContent
@@ -38,6 +41,14 @@ func _ready():
 	presenter.synchronizer.sync_state_change.connect(func(v): show_sync_in_progress(v))
 
 	presenter.on_ready()
+
+	for method in AssetSortBy.SortMethod.keys():
+		sort_button.add_item( method.capitalize(), AssetSortBy.SortMethod[method])
+
+	sort_button.selected = 0
+	sort_button.item_selected.connect(presenter.on_sort_method_change)
+	ascending_order_button.pressed.connect(flip_order)
+
 	add_folder_button.pressed.connect(show_folder_dialog)
 	search_field.text_changed.connect(presenter.on_query_change)
 	reload_button.pressed.connect(presenter.sync)
@@ -135,6 +146,16 @@ func set_selected_asset(asset: AssetResource):
 	for child in grid_container.get_children():
 		if child is AssetResourcePreview:
 			child.select_not_signal(child.get_meta("id") == asset.id)
+
+
+func flip_order():
+	ascending_order_button.pivot_offset = ascending_order_button.size / 2
+	ascending_order_button.scale.y *= -1
+	var text := "Sort by %s order." % ("ascending" if presenter.is_sort_ascending else "descending")
+	ascending_order_button.tooltip_text = text
+
+	presenter.is_sort_ascending = not presenter.is_sort_ascending
+	presenter._filter_by_collections_and_query()
 
 
 func show_empty_view(type: AssetLibraryPresenter.EmptyType):

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://3qun24bndqll"]
+[gd_scene load_steps=14 format=3 uid="uid://3qun24bndqll"]
 
 [ext_resource type="Script" uid="uid://d3hm5bn8vmd2" path="res://addons/asset_placer/ui/asset_library_window/asset_library_window.gd" id="1_l06eo"]
 [ext_resource type="PackedScene" uid="uid://dua2vx4bi1gmf" path="res://addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn" id="2_qx6qk"]
@@ -8,12 +8,19 @@
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5cqey"]
 
-[sub_resource type="Texture2D" id="Texture2D_gvdec"]
-resource_local_to_scene = false
-resource_name = ""
-script = ExtResource("3_gvdec")
-icon_name = &"Search"
-metadata/_custom_type_script = "uid://dmicn3kmr620j"
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qx6qk"]
+content_margin_left = 0.0
+content_margin_top = 0.0
+content_margin_right = 0.0
+content_margin_bottom = 0.0
+bg_color = Color(0.07846785, 0.07846785, 0.07846785, 0.65000004)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+corner_detail = 5
+expand_margin_left = 6.0
+expand_margin_top = 4.0
 
 [sub_resource type="Texture2D" id="Texture2D_yvyyx"]
 resource_local_to_scene = false
@@ -43,6 +50,20 @@ resource_local_to_scene = false
 resource_name = ""
 script = ExtResource("3_gvdec")
 icon_name = &"Reload"
+metadata/_custom_type_script = "uid://dmicn3kmr620j"
+
+[sub_resource type="Texture2D" id="Texture2D_2650m"]
+resource_local_to_scene = false
+resource_name = ""
+script = ExtResource("3_gvdec")
+icon_name = &"Sort"
+metadata/_custom_type_script = "uid://dmicn3kmr620j"
+
+[sub_resource type="Texture2D" id="Texture2D_gvdec"]
+resource_local_to_scene = false
+resource_name = ""
+script = ExtResource("3_gvdec")
+icon_name = &"Search"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
 [sub_resource type="Texture2D" id="Texture2D_mdpb8"]
@@ -114,44 +135,63 @@ layout_mode = 2
 theme_override_constants/separation = 0
 alignment = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_qx6qk")
+
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 6
 theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 16
 alignment = 2
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 1
+
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/Control"]
+layout_mode = 0
+offset_top = -6.0
+offset_right = 410.0
+offset_bottom = 44.0
+size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 36
 text = "Assets"
 
-[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 4
-texture = SubResource("Texture2D_gvdec")
-stretch_mode = 5
-
-[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(300, 0)
+visible = false
+custom_minimum_size = Vector2(100, 10)
 layout_mode = 2
+size_flags_horizontal = 4
 size_flags_vertical = 4
-placeholder_text = "Filter assets by name"
+indeterminate = true
+editor_preview_indeterminate = true
 
-[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="HBoxContainerTop" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+alignment = 2
+
+[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Edit"
 icon = SubResource("Texture2D_yvyyx")
+icon_alignment = 1
 
-[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer/FilterButton"]
+[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/FilterButton"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
@@ -171,29 +211,70 @@ text = "0"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "FolderCreate"
 icon = SubResource("Texture2D_5cqey")
+icon_alignment = 1
 
-[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_vertical = 4
 text = "Sync Assets"
 icon = SubResource("Texture2D_qx6qk")
 
-[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+layout_mode = 2
+text = "Sort by"
+
+[node name="SortButton" type="OptionButton" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
 unique_name_in_owner = true
-visible = false
-custom_minimum_size = Vector2(100, 10)
+custom_minimum_size = Vector2(120, 32)
 layout_mode = 2
 size_flags_horizontal = 4
+
+[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+custom_minimum_size = Vector2(32, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="AscendingOrderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/Control"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 0
+offset_right = 32.0
+offset_bottom = 31.0
+scale = Vector2(1, -1)
+pivot_offset = Vector2(14, 16)
+size_flags_horizontal = 4
 size_flags_vertical = 4
-indeterminate = true
-editor_preview_indeterminate = true
+text = "
+"
+icon = SubResource("Texture2D_2650m")
+icon_alignment = 1
+
+[node name="HBoxContainerBot" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+alignment = 2
+
+[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot"]
+layout_mode = 2
+size_flags_vertical = 4
+texture = SubResource("Texture2D_gvdec")
+stretch_mode = 5
+
+[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+size_flags_vertical = 4
+placeholder_text = "Filter assets by name"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -168,13 +168,14 @@ layout_mode = 2
 theme_override_constants/separation = 8
 
 [node name="HBoxContainerTop" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=263426647]
+custom_minimum_size = Vector2(0, 34)
 layout_mode = 2
 theme_override_constants/separation = 8
 alignment = 2
 
 [node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=723111635]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(32, 32)
+custom_minimum_size = Vector2(34, 34)
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Filter by Collection"
@@ -203,7 +204,7 @@ vertical_alignment = 1
 
 [node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1736028897]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(32, 32)
+custom_minimum_size = Vector2(34, 34)
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Add Assets from Folder"
@@ -215,7 +216,7 @@ layout_mode = 2
 
 [node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=389049027]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 32)
+custom_minimum_size = Vector2(0, 34)
 layout_mode = 2
 size_flags_vertical = 4
 text = "Sync Assets"
@@ -237,7 +238,7 @@ text = "Sort by"
 
 [node name="SortButton" type="OptionButton" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1145968409]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(120, 32)
+custom_minimum_size = Vector2(120, 34)
 layout_mode = 2
 size_flags_horizontal = 4
 
@@ -248,12 +249,12 @@ size_flags_horizontal = 3
 
 [node name="AscendingOrderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/Control" unique_id=1469154313]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(32, 32)
+custom_minimum_size = Vector2(34, 34)
 layout_mode = 0
-offset_right = 32.0
-offset_bottom = 31.0
+offset_right = 34.0
+offset_bottom = 34.0
 scale = Vector2(1, -1)
-pivot_offset = Vector2(14, 16)
+pivot_offset_ratio = Vector2(0.5, 0.5)
 size_flags_horizontal = 4
 size_flags_vertical = 4
 tooltip_text = "Sort by descending order."

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -151,18 +151,17 @@ theme_override_constants/margin_bottom = 8
 layout_mode = 2
 alignment = 2
 
-[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=391569685]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=659313167]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/margin_top = -32
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/Control" unique_id=530689257]
-layout_mode = 0
-offset_top = -6.0
-offset_right = 410.0
-offset_bottom = 44.0
-size_flags_horizontal = 3
+[node name="AssetsLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/MarginContainer" unique_id=1180368063]
+unique_name_in_owner = true
+layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Assets"
+text_overrun_behavior = 1
 
 [node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=578510117]
 unique_name_in_owner = true

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -1,8 +1,12 @@
-[gd_scene load_steps=10 format=3 uid="uid://3qun24bndqll"]
+[gd_scene load_steps=12 format=3 uid="uid://3qun24bndqll"]
 
 [ext_resource type="Script" uid="uid://d3hm5bn8vmd2" path="res://addons/asset_placer/ui/asset_library_window/asset_library_window.gd" id="1_l06eo"]
 [ext_resource type="PackedScene" uid="uid://dua2vx4bi1gmf" path="res://addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn" id="2_qx6qk"]
 [ext_resource type="Script" uid="uid://dmicn3kmr620j" path="res://addons/asset_placer/utils/system_icon.gd" id="3_gvdec"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_qx6qk"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5cqey"]
 
 [sub_resource type="Texture2D" id="Texture2D_gvdec"]
 resource_local_to_scene = false
@@ -53,22 +57,14 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_bottom = 145.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_vertical = 3
 mouse_filter = 1
 script = ExtResource("1_l06eo")
 
-[node name="Panel" type="Panel" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 1
-
-[node name="MainContent" type="HSplitContainer" parent="Panel"]
+[node name="MainContent" type="HSplitContainer" parent="."]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -76,64 +72,86 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-split_offset = -370
+theme_override_constants/separation = 6
+split_offset = 350
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MainContent"]
+[node name="PanelContainer" type="PanelContainer" parent="MainContent"]
 layout_mode = 2
-size_flags_horizontal = 3
+theme_override_styles/panel = SubResource("StyleBoxEmpty_qx6qk")
 
-[node name="AssetPlacerOptions" parent="Panel/MainContent/ScrollContainer" instance=ExtResource("2_qx6qk")]
+[node name="Panel" type="Panel" parent="MainContent/PanelContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer"]
 clip_contents = true
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-localize_numeral_system = false
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_bottom = 4
 
-[node name="MarginContainer" type="MarginContainer" parent="Panel/MainContent"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer/MarginContainer"]
+clip_contents = false
+layout_mode = 2
+
+[node name="AssetPlacerOptions" parent="MainContent/PanelContainer/MarginContainer/ScrollContainer" instance=ExtResource("2_qx6qk")]
+layout_mode = 2
+
+[node name="PanelContainer2" type="PanelContainer" parent="MainContent"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/margin_left = 16
-theme_override_constants/margin_top = 16
-theme_override_constants/margin_right = 16
-theme_override_constants/margin_bottom = 16
+theme_override_styles/panel = SubResource("StyleBoxEmpty_5cqey")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MainContent/MarginContainer"]
+[node name="Panel" type="Panel" parent="MainContent/PanelContainer2"]
 layout_mode = 2
-theme_override_constants/separation = 32
+
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 6
+theme_override_constants/margin_top = 4
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 0
 alignment = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_right = 8
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer"]
 layout_mode = 2
 theme_override_constants/separation = 16
 alignment = 2
 
-[node name="Label" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_vertical = 1
 theme_override_font_sizes/font_size = 36
 text = "Assets"
 
-[node name="TextureRect" type="TextureRect" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 4
 texture = SubResource("Texture2D_gvdec")
 stretch_mode = 5
 
-[node name="SearchField" type="LineEdit" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_vertical = 4
 placeholder_text = "Filter assets by name"
 
-[node name="FilterButton" type="Button" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Edit"
 icon = SubResource("Texture2D_yvyyx")
 
-[node name="FiltersLabel" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer/FilterButton"]
+[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer/FilterButton"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
@@ -153,21 +171,21 @@ text = "0"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="AddFolderButton" type="Button" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "FolderCreate"
 icon = SubResource("Texture2D_5cqey")
 
-[node name="ReloadButton" type="Button" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 text = "Sync Assets"
 icon = SubResource("Texture2D_qx6qk")
 
-[node name="ProgressBar" type="ProgressBar" parent="Panel/MainContent/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(100, 10)
@@ -177,136 +195,135 @@ size_flags_vertical = 4
 indeterminate = true
 editor_preview_indeterminate = true
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="GridContainer" type="HFlowContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="GridContainer" type="HFlowContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/ScrollContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="EmptyCollectionContent" type="CenterContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer"]
+[node name="EmptyCollectionContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="VBoxContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent"]
+[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent"]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "No assets in this collection"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
 layout_mode = 2
-text = "This collection currently has no assets assigned. 
+text = "This collection currently has no assets assigned.
 You can Drag and Drop assets/folders into this window to fix that!"
 horizontal_alignment = 1
 
-[node name="Label3" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
 layout_mode = 2
 
-[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer/CenterContainer"]
+[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer/CenterContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Add Folders  Using Dialog"
 icon = SubResource("Texture2D_mdpb8")
 
-[node name="EmptySearchContent" type="CenterContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer"]
+[node name="EmptySearchContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="VBoxContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent"]
+[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent"]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "No assets found"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
 layout_mode = 2
 text = "No assets found that would have this name
 You can Drag and Drop assets/folders into this window to fix that!"
 horizontal_alignment = 1
 
-[node name="Label3" type="Label" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
 layout_mode = 2
 
-[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="Panel/MainContent/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer/CenterContainer"]
+[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer/CenterContainer"]
 layout_mode = 2
 text = "Add Folders  Using Dialog"
 icon = SubResource("Texture2D_mdpb8")
 
-[node name="EmptyContent" type="CenterContainer" parent="Panel"]
+[node name="EmptyContent" type="CenterContainer" parent="."]
 unique_name_in_owner = true
 visible = false
-layout_mode = 1
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="HBoxContainer" type="VBoxContainer" parent="Panel/EmptyContent"]
+[node name="HBoxContainer" type="VBoxContainer" parent="EmptyContent"]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="Panel/EmptyContent/HBoxContainer"]
+[node name="Label" type="Label" parent="EmptyContent/HBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Welcome to Asset Placer!"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="Panel/EmptyContent/HBoxContainer"]
+[node name="Space" type="Control" parent="EmptyContent/HBoxContainer"]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="Panel/EmptyContent/HBoxContainer"]
+[node name="Label2" type="Label" parent="EmptyContent/HBoxContainer"]
 layout_mode = 2
 text = "Start by draggin and dropping your folder with Assets or Asset files themeselves to get started"
 
-[node name="Label3" type="Label" parent="Panel/EmptyContent/HBoxContainer"]
+[node name="Label3" type="Label" parent="EmptyContent/HBoxContainer"]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="Panel/EmptyContent/HBoxContainer"]
+[node name="CenterContainer" type="CenterContainer" parent="EmptyContent/HBoxContainer"]
 layout_mode = 2
 
-[node name="EmptyViewAddFolderBtn" type="Button" parent="Panel/EmptyContent/HBoxContainer/CenterContainer"]
+[node name="EmptyViewAddFolderBtn" type="Button" parent="EmptyContent/HBoxContainer/CenterContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Add Folders  Using Dialog"

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -163,16 +163,6 @@ theme_override_font_sizes/font_size = 36
 text = "Assets"
 text_overrun_behavior = 1
 
-[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=578510117]
-unique_name_in_owner = true
-visible = false
-custom_minimum_size = Vector2(100, 10)
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-indeterminate = true
-editor_preview_indeterminate = true
-
 [node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=439730441]
 layout_mode = 2
 theme_override_constants/separation = 8
@@ -220,13 +210,26 @@ tooltip_text = "FolderCreate"
 icon = SubResource("Texture2D_5cqey")
 icon_alignment = 1
 
-[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=389049027]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1663076877]
+layout_mode = 2
+
+[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=389049027]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 size_flags_vertical = 4
 text = "Sync Assets"
 icon = SubResource("Texture2D_qx6qk")
+
+[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=578510117]
+unique_name_in_owner = true
+visible = false
+custom_minimum_size = Vector2(100, 10)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+indeterminate = true
+editor_preview_indeterminate = true
 
 [node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1774242199]
 layout_mode = 2
@@ -238,7 +241,7 @@ custom_minimum_size = Vector2(120, 32)
 layout_mode = 2
 size_flags_horizontal = 4
 selected = 0
-item_count = 4
+item_count = 8
 popup/item_0/text = "Name"
 popup/item_0/id = 0
 popup/item_1/text = "Last Placed"
@@ -247,6 +250,14 @@ popup/item_2/text = "Last Saved"
 popup/item_2/id = 2
 popup/item_3/text = "Date Added"
 popup/item_3/id = 3
+popup/item_4/text = "Name"
+popup/item_4/id = 0
+popup/item_5/text = "Last Placed"
+popup/item_5/id = 1
+popup/item_6/text = "Last Saved"
+popup/item_6/id = 2
+popup/item_7/text = "Date Added"
+popup/item_7/id = 3
 
 [node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=395794459]
 custom_minimum_size = Vector2(32, 0)

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://3qun24bndqll"]
+[gd_scene format=3 uid="uid://3qun24bndqll"]
 
 [ext_resource type="Script" uid="uid://d3hm5bn8vmd2" path="res://addons/asset_placer/ui/asset_library_window/asset_library_window.gd" id="1_l06eo"]
 [ext_resource type="PackedScene" uid="uid://dua2vx4bi1gmf" path="res://addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn" id="2_qx6qk"]
@@ -73,7 +73,7 @@ script = ExtResource("3_gvdec")
 icon_name = &"FolderCreate"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
-[node name="AssetLibraryWindow" type="Control"]
+[node name="AssetLibraryWindow" type="Control" unique_id=208186929]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -85,7 +85,7 @@ size_flags_vertical = 3
 mouse_filter = 1
 script = ExtResource("1_l06eo")
 
-[node name="MainContent" type="HSplitContainer" parent="."]
+[node name="MainContent" type="HSplitContainer" parent="." unique_id=481918574]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -94,67 +94,68 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 6
+split_offsets = PackedInt32Array(350)
 split_offset = 350
 
-[node name="PanelContainer" type="PanelContainer" parent="MainContent"]
+[node name="PanelContainer" type="PanelContainer" parent="MainContent" unique_id=814115667]
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxEmpty_qx6qk")
 
-[node name="Panel" type="Panel" parent="MainContent/PanelContainer"]
+[node name="Panel" type="Panel" parent="MainContent/PanelContainer" unique_id=323453695]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer" unique_id=177413274]
 clip_contents = true
 layout_mode = 2
 theme_override_constants/margin_top = 4
 theme_override_constants/margin_bottom = 4
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer/MarginContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer/MarginContainer" unique_id=447420490]
 clip_contents = false
 layout_mode = 2
 
-[node name="AssetPlacerOptions" parent="MainContent/PanelContainer/MarginContainer/ScrollContainer" instance=ExtResource("2_qx6qk")]
+[node name="AssetPlacerOptions" parent="MainContent/PanelContainer/MarginContainer/ScrollContainer" unique_id=315979078 instance=ExtResource("2_qx6qk")]
 layout_mode = 2
 
-[node name="PanelContainer2" type="PanelContainer" parent="MainContent"]
+[node name="PanelContainer2" type="PanelContainer" parent="MainContent" unique_id=1525485548]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxEmpty_5cqey")
 
-[node name="Panel" type="Panel" parent="MainContent/PanelContainer2"]
+[node name="Panel" type="Panel" parent="MainContent/PanelContainer2" unique_id=717920366]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2"]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2" unique_id=687641512]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/margin_left = 6
 theme_override_constants/margin_top = 4
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer" unique_id=1810251743]
 layout_mode = 2
 theme_override_constants/separation = 0
 alignment = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=811757333]
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_qx6qk")
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer" unique_id=296305669]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 6
 theme_override_constants/margin_right = 8
 theme_override_constants/margin_bottom = 8
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer" unique_id=1163473389]
 layout_mode = 2
 alignment = 2
 
-[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
+[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=391569685]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/Control"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/Control" unique_id=530689257]
 layout_mode = 0
 offset_top = -6.0
 offset_right = 410.0
@@ -163,7 +164,7 @@ size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 36
 text = "Assets"
 
-[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
+[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=578510117]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(100, 10)
@@ -173,16 +174,16 @@ size_flags_vertical = 4
 indeterminate = true
 editor_preview_indeterminate = true
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=439730441]
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="HBoxContainerTop" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="HBoxContainerTop" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=263426647]
 layout_mode = 2
 theme_override_constants/separation = 8
 alignment = 2
 
-[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=723111635]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
@@ -191,7 +192,7 @@ tooltip_text = "Edit"
 icon = SubResource("Texture2D_yvyyx")
 icon_alignment = 1
 
-[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/FilterButton"]
+[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/FilterButton" unique_id=2017174812]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
@@ -211,7 +212,7 @@ text = "0"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1736028897]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
@@ -220,7 +221,7 @@ tooltip_text = "FolderCreate"
 icon = SubResource("Texture2D_5cqey")
 icon_alignment = 1
 
-[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=389049027]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -228,22 +229,32 @@ size_flags_vertical = 4
 text = "Sync Assets"
 icon = SubResource("Texture2D_qx6qk")
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1774242199]
 layout_mode = 2
 text = "Sort by"
 
-[node name="SortButton" type="OptionButton" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+[node name="SortButton" type="OptionButton" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1145968409]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(120, 32)
 layout_mode = 2
 size_flags_horizontal = 4
+selected = 0
+item_count = 4
+popup/item_0/text = "Name"
+popup/item_0/id = 0
+popup/item_1/text = "Last Placed"
+popup/item_1/id = 1
+popup/item_2/text = "Last Saved"
+popup/item_2/id = 2
+popup/item_3/text = "Date Added"
+popup/item_3/id = 3
 
-[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop"]
+[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=395794459]
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="AscendingOrderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/Control"]
+[node name="AscendingOrderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/Control" unique_id=1469154313]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 0
@@ -258,117 +269,117 @@ text = "
 icon = SubResource("Texture2D_2650m")
 icon_alignment = 1
 
-[node name="HBoxContainerBot" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
+[node name="HBoxContainerBot" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=448990933]
 layout_mode = 2
 theme_override_constants/separation = 10
 alignment = 2
 
-[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot"]
+[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot" unique_id=1009293278]
 layout_mode = 2
 size_flags_vertical = 4
 texture = SubResource("Texture2D_gvdec")
 stretch_mode = 5
 
-[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot"]
+[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot" unique_id=650943463]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_vertical = 4
 placeholder_text = "Filter assets by name"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=1511808776]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="GridContainer" type="HFlowContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="GridContainer" type="HFlowContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/ScrollContainer" unique_id=2008987014]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="EmptyCollectionContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+[node name="EmptyCollectionContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=2105840377]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent"]
+[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent" unique_id=405080356]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=1598958730]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "No assets in this collection"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=2107497302]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=923357456]
 layout_mode = 2
 text = "This collection currently has no assets assigned.
 You can Drag and Drop assets/folders into this window to fix that!"
 horizontal_alignment = 1
 
-[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=1708860321]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer"]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=369917372]
 layout_mode = 2
 
-[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer/CenterContainer"]
+[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer/CenterContainer" unique_id=1001134906]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Add Folders  Using Dialog"
 icon = SubResource("Texture2D_mdpb8")
 
-[node name="EmptySearchContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer"]
+[node name="EmptySearchContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=961587485]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent"]
+[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent" unique_id=1297012161]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=498463512]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "No assets found"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=2143086520]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=1526199362]
 layout_mode = 2
 text = "No assets found that would have this name
 You can Drag and Drop assets/folders into this window to fix that!"
 horizontal_alignment = 1
 
-[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=2018307732]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer"]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=1434945112]
 layout_mode = 2
 
-[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer/CenterContainer"]
+[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer/CenterContainer" unique_id=1457677871]
 layout_mode = 2
 text = "Add Folders  Using Dialog"
 icon = SubResource("Texture2D_mdpb8")
 
-[node name="EmptyContent" type="CenterContainer" parent="."]
+[node name="EmptyContent" type="CenterContainer" parent="." unique_id=1062482879]
 unique_name_in_owner = true
 visible = false
 layout_mode = 0
@@ -377,34 +388,34 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="HBoxContainer" type="VBoxContainer" parent="EmptyContent"]
+[node name="HBoxContainer" type="VBoxContainer" parent="EmptyContent" unique_id=1619072534]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="EmptyContent/HBoxContainer"]
+[node name="Label" type="Label" parent="EmptyContent/HBoxContainer" unique_id=1068212013]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Welcome to Asset Placer!"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="EmptyContent/HBoxContainer"]
+[node name="Space" type="Control" parent="EmptyContent/HBoxContainer" unique_id=2143401228]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="EmptyContent/HBoxContainer"]
+[node name="Label2" type="Label" parent="EmptyContent/HBoxContainer" unique_id=1325353930]
 layout_mode = 2
 text = "Start by draggin and dropping your folder with Assets or Asset files themeselves to get started"
 
-[node name="Label3" type="Label" parent="EmptyContent/HBoxContainer"]
+[node name="Label3" type="Label" parent="EmptyContent/HBoxContainer" unique_id=2140884795]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="EmptyContent/HBoxContainer"]
+[node name="CenterContainer" type="CenterContainer" parent="EmptyContent/HBoxContainer" unique_id=405262687]
 layout_mode = 2
 
-[node name="EmptyViewAddFolderBtn" type="Button" parent="EmptyContent/HBoxContainer/CenterContainer"]
+[node name="EmptyViewAddFolderBtn" type="Button" parent="EmptyContent/HBoxContainer/CenterContainer" unique_id=1145600742]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Add Folders  Using Dialog"

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -177,7 +177,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 size_flags_vertical = 4
-tooltip_text = "Edit"
+tooltip_text = "Filter by Collection"
 icon = SubResource("Texture2D_yvyyx")
 icon_alignment = 1
 
@@ -206,7 +206,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 size_flags_vertical = 4
-tooltip_text = "FolderCreate"
+tooltip_text = "Add Assets from Folder"
 icon = SubResource("Texture2D_5cqey")
 icon_alignment = 1
 
@@ -256,8 +256,7 @@ scale = Vector2(1, -1)
 pivot_offset = Vector2(14, 16)
 size_flags_horizontal = 4
 size_flags_vertical = 4
-text = "
-"
+tooltip_text = "Sort by descending order."
 icon = SubResource("Texture2D_2650m")
 icon_alignment = 1
 

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -240,24 +240,6 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(120, 32)
 layout_mode = 2
 size_flags_horizontal = 4
-selected = 0
-item_count = 8
-popup/item_0/text = "Name"
-popup/item_0/id = 0
-popup/item_1/text = "Last Placed"
-popup/item_1/id = 1
-popup/item_2/text = "Last Saved"
-popup/item_2/id = 2
-popup/item_3/text = "Date Added"
-popup/item_3/id = 3
-popup/item_4/text = "Name"
-popup/item_4/id = 0
-popup/item_5/text = "Last Placed"
-popup/item_5/id = 1
-popup/item_6/text = "Last Saved"
-popup/item_6/id = 2
-popup/item_7/text = "Date Added"
-popup/item_7/id = 3
 
 [node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=395794459]
 custom_minimum_size = Vector2(32, 0)

--- a/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_window.tscn
@@ -19,8 +19,6 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
-expand_margin_left = 6.0
-expand_margin_top = 4.0
 
 [sub_resource type="Texture2D" id="Texture2D_yvyyx"]
 resource_local_to_scene = false
@@ -125,55 +123,50 @@ theme_override_styles/panel = SubResource("StyleBoxEmpty_5cqey")
 [node name="Panel" type="Panel" parent="MainContent/PanelContainer2" unique_id=717920366]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2" unique_id=687641512]
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_constants/margin_left = 6
-theme_override_constants/margin_top = 4
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer" unique_id=1810251743]
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2" unique_id=1810251743]
 layout_mode = 2
 theme_override_constants/separation = 0
 alignment = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=811757333]
+[node name="PanelContainer" type="PanelContainer" parent="MainContent/PanelContainer2/VBoxContainer" unique_id=811757333]
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_qx6qk")
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer" unique_id=296305669]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer" unique_id=296305669]
 layout_mode = 2
 theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 6
+theme_override_constants/margin_top = 8
 theme_override_constants/margin_right = 8
 theme_override_constants/margin_bottom = 8
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer" unique_id=1163473389]
+[node name="HBoxContainer" type="HBoxContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer" unique_id=1163473389]
 layout_mode = 2
 alignment = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=659313167]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=659313167]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/margin_top = -32
+theme_override_constants/margin_left = 6
+theme_override_constants/margin_top = -16
 
-[node name="AssetsLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/MarginContainer" unique_id=1180368063]
+[node name="AssetsLabel" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/MarginContainer" unique_id=1180368063]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Assets"
 text_overrun_behavior = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=439730441]
+[node name="VBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer" unique_id=439730441]
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="HBoxContainerTop" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=263426647]
+[node name="HBoxContainerTop" type="HBoxContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=263426647]
 custom_minimum_size = Vector2(0, 34)
 layout_mode = 2
 theme_override_constants/separation = 8
 alignment = 2
 
-[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=723111635]
+[node name="FilterButton" type="Button" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=723111635]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(34, 34)
 layout_mode = 2
@@ -182,7 +175,7 @@ tooltip_text = "Filter by Collection"
 icon = SubResource("Texture2D_yvyyx")
 icon_alignment = 1
 
-[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/FilterButton" unique_id=2017174812]
+[node name="FiltersLabel" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/FilterButton" unique_id=2017174812]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
@@ -202,7 +195,7 @@ text = "0"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1736028897]
+[node name="AddFolderButton" type="Button" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1736028897]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(34, 34)
 layout_mode = 2
@@ -211,10 +204,10 @@ tooltip_text = "Add Assets from Folder"
 icon = SubResource("Texture2D_5cqey")
 icon_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1663076877]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1663076877]
 layout_mode = 2
 
-[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=389049027]
+[node name="ReloadButton" type="Button" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=389049027]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 34)
 layout_mode = 2
@@ -222,7 +215,7 @@ size_flags_vertical = 4
 text = "Sync Assets"
 icon = SubResource("Texture2D_qx6qk")
 
-[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=578510117]
+[node name="ProgressBar" type="ProgressBar" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/CenterContainer" unique_id=578510117]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(100, 10)
@@ -232,22 +225,22 @@ size_flags_vertical = 4
 indeterminate = true
 editor_preview_indeterminate = true
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1774242199]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1774242199]
 layout_mode = 2
 text = "Sort by"
 
-[node name="SortButton" type="OptionButton" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1145968409]
+[node name="SortButton" type="OptionButton" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=1145968409]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(120, 34)
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="Control" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=395794459]
+[node name="Control" type="Control" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop" unique_id=395794459]
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="AscendingOrderButton" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/Control" unique_id=1469154313]
+[node name="AscendingOrderButton" type="Button" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerTop/Control" unique_id=1469154313]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(34, 34)
 layout_mode = 0
@@ -261,112 +254,117 @@ tooltip_text = "Sort by descending order."
 icon = SubResource("Texture2D_2650m")
 icon_alignment = 1
 
-[node name="HBoxContainerBot" type="HBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=448990933]
+[node name="HBoxContainerBot" type="HBoxContainer" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" unique_id=448990933]
 layout_mode = 2
 theme_override_constants/separation = 10
 alignment = 2
 
-[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot" unique_id=1009293278]
+[node name="TextureRect" type="TextureRect" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot" unique_id=1009293278]
 layout_mode = 2
 size_flags_vertical = 4
 texture = SubResource("Texture2D_gvdec")
 stretch_mode = 5
 
-[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot" unique_id=650943463]
+[node name="SearchField" type="LineEdit" parent="MainContent/PanelContainer2/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainerBot" unique_id=650943463]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_vertical = 4
 placeholder_text = "Filter assets by name"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=1511808776]
+[node name="MarginContainer" type="MarginContainer" parent="MainContent/PanelContainer2/VBoxContainer" unique_id=1274464248]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/margin_left = 6
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MainContent/PanelContainer2/VBoxContainer/MarginContainer" unique_id=1511808776]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="GridContainer" type="HFlowContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/ScrollContainer" unique_id=2008987014]
+[node name="GridContainer" type="HFlowContainer" parent="MainContent/PanelContainer2/VBoxContainer/MarginContainer/ScrollContainer" unique_id=2008987014]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="EmptyCollectionContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=2105840377]
+[node name="EmptyCollectionContent" type="CenterContainer" parent="MainContent/PanelContainer2/VBoxContainer" unique_id=2105840377]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent" unique_id=405080356]
+[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent" unique_id=405080356]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=1598958730]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=1598958730]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "No assets in this collection"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=2107497302]
+[node name="Space" type="Control" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=2107497302]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=923357456]
+[node name="Label2" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=923357456]
 layout_mode = 2
 text = "This collection currently has no assets assigned.
 You can Drag and Drop assets/folders into this window to fix that!"
 horizontal_alignment = 1
 
-[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=1708860321]
+[node name="Label3" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=1708860321]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=369917372]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent/HBoxContainer" unique_id=369917372]
 layout_mode = 2
 
-[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptyCollectionContent/HBoxContainer/CenterContainer" unique_id=1001134906]
+[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/VBoxContainer/EmptyCollectionContent/HBoxContainer/CenterContainer" unique_id=1001134906]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Add Folders  Using Dialog"
 icon = SubResource("Texture2D_mdpb8")
 
-[node name="EmptySearchContent" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer" unique_id=961587485]
+[node name="EmptySearchContent" type="CenterContainer" parent="MainContent/PanelContainer2/VBoxContainer" unique_id=961587485]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent" unique_id=1297012161]
+[node name="HBoxContainer" type="VBoxContainer" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent" unique_id=1297012161]
 layout_mode = 2
 theme_override_constants/separation = 12
 alignment = 1
 
-[node name="Label" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=498463512]
+[node name="Label" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=498463512]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "No assets found"
 horizontal_alignment = 1
 
-[node name="Space" type="Control" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=2143086520]
+[node name="Space" type="Control" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=2143086520]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=1526199362]
+[node name="Label2" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=1526199362]
 layout_mode = 2
 text = "No assets found that would have this name
 You can Drag and Drop assets/folders into this window to fix that!"
 horizontal_alignment = 1
 
-[node name="Label3" type="Label" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=2018307732]
+[node name="Label3" type="Label" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=2018307732]
 layout_mode = 2
 text = "Or"
 horizontal_alignment = 1
 
-[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=1434945112]
+[node name="CenterContainer" type="CenterContainer" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent/HBoxContainer" unique_id=1434945112]
 layout_mode = 2
 
-[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/MarginContainer/VBoxContainer/EmptySearchContent/HBoxContainer/CenterContainer" unique_id=1457677871]
+[node name="EmptyCollectionViewAddFolderBtn" type="Button" parent="MainContent/PanelContainer2/VBoxContainer/EmptySearchContent/HBoxContainer/CenterContainer" unique_id=1457677871]
 layout_mode = 2
 text = "Add Folders  Using Dialog"
 icon = SubResource("Texture2D_mdpb8")

--- a/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
@@ -13,27 +13,29 @@ enum SortMethod {
 }
 
 
-static func sort_by_name(left: AssetResource, right: AssetResource) -> bool:
-	return left.name.naturalcasecmp_to(right.name) < 0
+static func sort_by_name(left: AssetResource, right: AssetResource, ascending_order := true) -> bool:
+	return not (ascending_order != (left.name.naturalnocasecmp_to(right.name) < 0))
 
 
-static func sort_by_date_added(left: AssetResource, right: AssetResource):
-	return left.date_added < right.date_added
+static func sort_by_date_added(
+	left: AssetResource, right: AssetResource, ascending_order := true
+) -> bool:
+	if ascending_order:
+		return left.date_added < right.date_added
+	return left.date_added > right.date_added
+
 
 
 static func get_sort_function(method: SortMethod, ascending_order := true) -> Callable:
 	var fun: Callable
 	match method:
 		SortMethod.Name:
-			fun = sort_by_name
+			fun = sort_by_name.bind(ascending_order)
 		SortMethod.DateAdded:
-			fun = sort_by_date_added
+			fun = sort_by_date_added.bind(ascending_order)
 		_:
 			push_warning("Chosen SortMethod %s is not supported." % method)
 			fun = _default_sort
-
-	if not ascending_order:
-		return func(left, right): return not fun.call(left, right)
 
 	return fun
 

--- a/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
@@ -12,7 +12,9 @@ enum SortMethod {
 }
 
 
-static func sort_by_name(left: AssetResource, right: AssetResource, ascending_order := true) -> bool:
+static func sort_by_name(
+	left: AssetResource, right: AssetResource, ascending_order := true
+) -> bool:
 	return not (ascending_order != (left.name.naturalnocasecmp_to(right.name) < 0))
 
 
@@ -24,17 +26,17 @@ static func sort_by_date_added(
 	return left.date_added > right.date_added
 
 
-
-static func sort_by_last_placed(left: AssetResource, right: AssetResource, ascending_order := true):
+static func sort_by_last_placed(
+	left: AssetResource, right: AssetResource, ascending_order := true
+) -> bool:
 	var es := APEditorSettingsManager.get_editor_settings()
 	var dict := es.get_assets_time_placed()
 	var left_val = dict.get(left.id, 0.0)
 	var right_val = dict.get(right.id, 0.0)
-	# if right_val == 0.0 and left_val == 0.0:
-	# 	return false
 	if ascending_order:
 		return left_val > right_val
 	return left_val < right_val
+
 
 static func get_sort_function(method: SortMethod, ascending_order := true) -> Callable:
 	var fun: Callable
@@ -53,5 +55,5 @@ static func get_sort_function(method: SortMethod, ascending_order := true) -> Ca
 
 
 ## Do not sort by default.
-static func _default_sort(left: AssetResource, right: AssetResource) -> bool:
+static func _default_sort(_left: AssetResource, _right: AssetResource) -> bool:
 	return false

--- a/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
@@ -7,9 +7,8 @@ extends RefCounted
 
 enum SortMethod {
 	Name,
-	LastPlaced,
-	LastSaved,
 	DateAdded,
+	LastPlaced,
 }
 
 
@@ -26,6 +25,17 @@ static func sort_by_date_added(
 
 
 
+static func sort_by_last_placed(left: AssetResource, right: AssetResource, ascending_order := true):
+	var es := APEditorSettingsManager.get_editor_settings()
+	var dict := es.get_assets_time_placed()
+	var left_val = dict.get(left.id, 0.0)
+	var right_val = dict.get(right.id, 0.0)
+	# if right_val == 0.0 and left_val == 0.0:
+	# 	return false
+	if ascending_order:
+		return left_val > right_val
+	return left_val < right_val
+
 static func get_sort_function(method: SortMethod, ascending_order := true) -> Callable:
 	var fun: Callable
 	match method:
@@ -33,6 +43,8 @@ static func get_sort_function(method: SortMethod, ascending_order := true) -> Ca
 			fun = sort_by_name.bind(ascending_order)
 		SortMethod.DateAdded:
 			fun = sort_by_date_added.bind(ascending_order)
+		SortMethod.LastPlaced:
+			fun = sort_by_last_placed.bind(ascending_order)
 		_:
 			push_warning("Chosen SortMethod %s is not supported." % method)
 			fun = _default_sort

--- a/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
@@ -17,11 +17,17 @@ static func sort_by_name(left: AssetResource, right: AssetResource) -> bool:
 	return left.name.naturalcasecmp_to(right.name) < 0
 
 
+static func sort_by_date_added(left: AssetResource, right: AssetResource):
+	return left.date_added < right.date_added
+
+
 static func get_sort_function(method: SortMethod, ascending_order := true) -> Callable:
 	var fun: Callable
 	match method:
 		SortMethod.Name:
 			fun = sort_by_name
+		SortMethod.DateAdded:
+			fun = sort_by_date_added
 		_:
 			push_warning("Chosen SortMethod %s is not supported." % method)
 			fun = _default_sort

--- a/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd
@@ -1,0 +1,37 @@
+@tool
+class_name AssetSortBy
+extends RefCounted
+
+## Class with sorting methods for AssetResource.
+## All methods sort in ascending order by default.
+
+enum SortMethod {
+	Name,
+	LastPlaced,
+	LastSaved,
+	DateAdded,
+}
+
+
+static func sort_by_name(left: AssetResource, right: AssetResource) -> bool:
+	return left.name.naturalcasecmp_to(right.name) < 0
+
+
+static func get_sort_function(method: SortMethod, ascending_order := true) -> Callable:
+	var fun: Callable
+	match method:
+		SortMethod.Name:
+			fun = sort_by_name
+		_:
+			push_warning("Chosen SortMethod %s is not supported." % method)
+			fun = _default_sort
+
+	if not ascending_order:
+		return func(left, right): return not fun.call(left, right)
+
+	return fun
+
+
+## Do not sort by default.
+static func _default_sort(left: AssetResource, right: AssetResource) -> bool:
+	return false

--- a/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd.uid
+++ b/addons/asset_placer/ui/asset_library_window/asset_sort_by.gd.uid
@@ -1,0 +1,1 @@
+uid://d34qcb4l7tn58

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn
@@ -73,52 +73,40 @@ script = ExtResource("2_o45xf")
 icon_name = &"KeyTrackScale"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
-[node name="AssetPlacerOptions" type="Control" unique_id=1666839685]
-layout_mode = 3
+[node name="AssetPlacerOptions" type="MarginContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_bottom = 12
 script = ExtResource("1_7uy5w")
 
-[node name="MarginContainer" type="MarginContainer" parent="." unique_id=2003363285]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 16
-theme_override_constants/margin_top = 16
-theme_override_constants/margin_right = 16
-theme_override_constants/margin_bottom = 16
-
-[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer" unique_id=949490987]
-layout_mode = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer" unique_id=846697167]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 theme_override_constants/separation = 16
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=438276497]
+[node name="Label" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Options"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=841451730]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="TextureRect" type="TextureRect" parent="MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=562381505]
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
 texture = SubResource("Texture2D_rixd2")
 stretch_mode = 3
 
-[node name="Label2" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1032040985]
+[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "Assets Parent: "
 
-[node name="ParentButton" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1858740301]
+[node name="ParentButton" type="Button" parent="VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -126,43 +114,43 @@ text = "No parent selected"
 icon = SubResource("Texture2D_o45xf")
 alignment = 0
 
-[node name="UseSelectionForParentCheckBox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1530175407]
+[node name="UseSelectionForParentCheckBox" type="CheckBox" parent="VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Resolve Parent from Selected Nodes"
 
-[node name="AutoGroupContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=335466325]
+[node name="AutoGroupContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="GroupAutomaticallyCheckBox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer/AutoGroupContainer" unique_id=1305167927]
+[node name="GroupAutomaticallyCheckBox" type="CheckBox" parent="VBoxContainer/AutoGroupContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Auto-Group by Collections"
 icon = SubResource("Texture2D_h8tp4")
 
-[node name="InfoButton" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer/AutoGroupContainer" unique_id=1432641978]
+[node name="InfoButton" type="Button" parent="VBoxContainer/AutoGroupContainer"]
 layout_mode = 2
-tooltip_text = "Automatically groups placed Assets based on their primary collection. 
+tooltip_text = "Automatically groups placed Assets based on their primary collection.
 New Parent Node will be created automatically and will have the same name as primary Collection.
 Assets without Primary collection will be placed under currently selected root node"
 icon = SubResource("Texture2D_h1wu1")
 flat = true
 
-[node name="PlacementMode" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1064773022]
+[node name="PlacementMode" type="VBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode" unique_id=738095851]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PlacementMode"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer" unique_id=582159956]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer"]
 layout_mode = 2
 
-[node name="PlacementModeLabel" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer" unique_id=807566098]
+[node name="PlacementModeLabel" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "Placement Mode: "
 
-[node name="PlacementModeOptionsButton" type="OptionButton" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer" unique_id=2009767270]
+[node name="PlacementModeOptionsButton" type="OptionButton" parent="VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 selected = 0
@@ -174,16 +162,16 @@ popup/item_1/id = 1
 popup/item_2/text = "Terrain3D"
 popup/item_2/id = 2
 
-[node name="PlaneOriginContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer" unique_id=1203253942]
+[node name="PlaneOriginContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer" unique_id=136130072]
+[node name="Label" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer"]
 layout_mode = 2
 text = "Plane Origin:   "
 
-[node name="PlaneOriginSpinBox" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer" unique_id=1895799156]
+[node name="PlaneOriginSpinBox" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -191,16 +179,16 @@ min = Vector3(-100, -100, -100)
 max = Vector3(100, 100, 100)
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="PlaneAxisContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer" unique_id=448694089]
+[node name="PlaneAxisContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer" unique_id=1536985010]
+[node name="Label" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer"]
 layout_mode = 2
 text = "Plane Normal: "
 
-[node name="PlaneAxisSpinBox" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer" unique_id=943080668]
+[node name="PlaneAxisSpinBox" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -209,89 +197,91 @@ max = Vector3(1, 1, 1)
 normalized = true
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=73176294]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="RandomAssetCheckBox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer/VBoxContainer" unique_id=1248668348]
+[node name="RandomAssetCheckBox" type="CheckBox" parent="VBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Enable Random Asset Placement"
 icon = SubResource("Texture2D_br0rc")
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/VBoxContainer" unique_id=15321030]
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer"]
+custom_minimum_size = Vector2(315, 0)
 layout_mode = 2
+size_flags_horizontal = 0
 theme_override_font_sizes/font_size = 14
 text = "Experimental: This option will pick item from the currently visible assets  after each placement"
 autowrap_mode = 2
 
-[node name="Snapping" type="BoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=2065658864]
+[node name="Snapping" type="BoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/Snapping" unique_id=875568453]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Snapping"]
 layout_mode = 2
 
-[node name="GridSnappingCheckbox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer/Snapping/VBoxContainer" unique_id=317108675]
+[node name="GridSnappingCheckbox" type="CheckBox" parent="VBoxContainer/Snapping/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Grid Snapping"
 icon = SubResource("Texture2D_5lmt4")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/Snapping/VBoxContainer" unique_id=1162207188]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Snapping/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/Snapping/VBoxContainer/HBoxContainer" unique_id=1776988120]
+[node name="Label" type="Label" parent="VBoxContainer/Snapping/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 text = "Grid Step"
 
-[node name="GridSnapValueSpinBox" type="SpinBox" parent="MarginContainer/ScrollContainer/VBoxContainer/Snapping/VBoxContainer/HBoxContainer" unique_id=1759703727]
+[node name="GridSnapValueSpinBox" type="SpinBox" parent="VBoxContainer/Snapping/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 step = 0.01
 value = 1.0
 editable = false
 
-[node name="AlignNormalsCheckbox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1748892708]
+[node name="AlignNormalsCheckbox" type="CheckBox" parent="VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Align Normals"
 icon = SubResource("Texture2D_5hqbk")
 
-[node name="UseAssetsOriginCheckbox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1904909633]
+[node name="UseAssetsOriginCheckbox" type="CheckBox" parent="VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Use Assets Origin"
 icon = SubResource("Texture2D_dewax")
 
-[node name="FoldableContainer" type="BoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1383293929]
+[node name="FoldableContainer" type="BoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer" unique_id=374078349]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/FoldableContainer"]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer" unique_id=1207437820]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_top = 16
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer" unique_id=1592214871]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="RandomRotationCheckBox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer/HBoxContainer" unique_id=153072207]
+[node name="RandomRotationCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Randomize Rotation On Placement"
 icon = SubResource("Texture2D_nfir2")
 
-[node name="GridContainer" type="GridContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer" unique_id=717140374]
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
 layout_mode = 2
 columns = 2
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=493457162]
+[node name="Label" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
 layout_mode = 2
 text = "Min"
 
-[node name="MinRotationSelector" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=357012014]
+[node name="MinRotationSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -299,11 +289,11 @@ min = Vector3(-180, -180, -180)
 max = Vector3(180, 180, 180)
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="Label2" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=128182506]
+[node name="Label2" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
 layout_mode = 2
 text = "Max"
 
-[node name="MaxRotationSelector" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=1459005158]
+[node name="MaxRotationSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -311,34 +301,34 @@ min = Vector3(-180, -180, -180)
 max = Vector3(180, 180, 180)
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="MarginContainer2" type="MarginContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer" unique_id=538807258]
+[node name="MarginContainer2" type="MarginContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_top = 16
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2" unique_id=400273966]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2"]
 layout_mode = 2
 
-[node name="RandomScaleCheckBox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2/HBoxContainer" unique_id=880488131]
+[node name="RandomScaleCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Randomize Scale On Placement"
 icon = SubResource("Texture2D_ik2kd")
 
-[node name="UniformScaleCheckBox" type="CheckBox" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer" unique_id=1189370336]
+[node name="UniformScaleCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Unform Scaling"
 
-[node name="GridContainer2" type="GridContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer" unique_id=680221302]
+[node name="GridContainer2" type="GridContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
 layout_mode = 2
 columns = 2
 
-[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=1458880303]
+[node name="Label" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2
 text = "Min"
 
-[node name="MinScaleSelector" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=1934125411]
+[node name="MinScaleSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -347,11 +337,11 @@ max = Vector3(100, 100, 100)
 uniform = true
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="Label2" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=551398598]
+[node name="Label2" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2
 text = "Max"
 
-[node name="MaxScaleSelector" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=1013378245]
+[node name="MaxScaleSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.tscn
@@ -73,7 +73,7 @@ script = ExtResource("2_o45xf")
 icon_name = &"KeyTrackScale"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
-[node name="AssetPlacerOptions" type="MarginContainer"]
+[node name="AssetPlacerOptions" type="MarginContainer" unique_id=540934569]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -85,28 +85,28 @@ theme_override_constants/margin_left = 16
 theme_override_constants/margin_bottom = 12
 script = ExtResource("1_7uy5w")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=271010355]
 layout_mode = 2
 theme_override_constants/separation = 16
 
-[node name="Label" type="Label" parent="VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer" unique_id=1381235482]
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Options"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer" unique_id=876043794]
 layout_mode = 2
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/HBoxContainer" unique_id=323794363]
 layout_mode = 2
 texture = SubResource("Texture2D_rixd2")
 stretch_mode = 3
 
-[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer"]
+[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer" unique_id=1866514757]
 layout_mode = 2
 text = "Assets Parent: "
 
-[node name="ParentButton" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="ParentButton" type="Button" parent="VBoxContainer/HBoxContainer" unique_id=1962048152]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -114,22 +114,22 @@ text = "No parent selected"
 icon = SubResource("Texture2D_o45xf")
 alignment = 0
 
-[node name="UseSelectionForParentCheckBox" type="CheckBox" parent="VBoxContainer"]
+[node name="UseSelectionForParentCheckBox" type="CheckBox" parent="VBoxContainer" unique_id=438547014]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Resolve Parent from Selected Nodes"
 
-[node name="AutoGroupContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="AutoGroupContainer" type="HBoxContainer" parent="VBoxContainer" unique_id=357839780]
 layout_mode = 2
 
-[node name="GroupAutomaticallyCheckBox" type="CheckBox" parent="VBoxContainer/AutoGroupContainer"]
+[node name="GroupAutomaticallyCheckBox" type="CheckBox" parent="VBoxContainer/AutoGroupContainer" unique_id=1107220742]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Auto-Group by Collections"
 icon = SubResource("Texture2D_h8tp4")
 
-[node name="InfoButton" type="Button" parent="VBoxContainer/AutoGroupContainer"]
+[node name="InfoButton" type="Button" parent="VBoxContainer/AutoGroupContainer" unique_id=2050820169]
 layout_mode = 2
 tooltip_text = "Automatically groups placed Assets based on their primary collection.
 New Parent Node will be created automatically and will have the same name as primary Collection.
@@ -137,20 +137,20 @@ Assets without Primary collection will be placed under currently selected root n
 icon = SubResource("Texture2D_h1wu1")
 flat = true
 
-[node name="PlacementMode" type="VBoxContainer" parent="VBoxContainer"]
+[node name="PlacementMode" type="VBoxContainer" parent="VBoxContainer" unique_id=446228019]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PlacementMode"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/PlacementMode" unique_id=1300628247]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer" unique_id=156474023]
 layout_mode = 2
 
-[node name="PlacementModeLabel" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer"]
+[node name="PlacementModeLabel" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer" unique_id=917484340]
 layout_mode = 2
 text = "Placement Mode: "
 
-[node name="PlacementModeOptionsButton" type="OptionButton" parent="VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer"]
+[node name="PlacementModeOptionsButton" type="OptionButton" parent="VBoxContainer/PlacementMode/VBoxContainer/HBoxContainer" unique_id=2069183827]
 unique_name_in_owner = true
 layout_mode = 2
 selected = 0
@@ -162,16 +162,16 @@ popup/item_1/id = 1
 popup/item_2/text = "Terrain3D"
 popup/item_2/id = 2
 
-[node name="PlaneOriginContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer"]
+[node name="PlaneOriginContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer" unique_id=1225273332]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer" unique_id=402122061]
 layout_mode = 2
 text = "Plane Origin:   "
 
-[node name="PlaneOriginSpinBox" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer"]
+[node name="PlaneOriginSpinBox" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneOriginContainer" unique_id=1319791006]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -179,16 +179,16 @@ min = Vector3(-100, -100, -100)
 max = Vector3(100, 100, 100)
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="PlaneAxisContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer"]
+[node name="PlaneAxisContainer" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer" unique_id=812376773]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer" unique_id=170558017]
 layout_mode = 2
 text = "Plane Normal: "
 
-[node name="PlaneAxisSpinBox" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer"]
+[node name="PlaneAxisSpinBox" type="HBoxContainer" parent="VBoxContainer/PlacementMode/VBoxContainer/PlaneAxisContainer" unique_id=715021554]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -197,16 +197,16 @@ max = Vector3(1, 1, 1)
 normalized = true
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer" unique_id=1976438150]
 layout_mode = 2
 
-[node name="RandomAssetCheckBox" type="CheckBox" parent="VBoxContainer/VBoxContainer"]
+[node name="RandomAssetCheckBox" type="CheckBox" parent="VBoxContainer/VBoxContainer" unique_id=876857783]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Enable Random Asset Placement"
 icon = SubResource("Texture2D_br0rc")
 
-[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer" unique_id=260316837]
 custom_minimum_size = Vector2(315, 0)
 layout_mode = 2
 size_flags_horizontal = 0
@@ -214,74 +214,74 @@ theme_override_font_sizes/font_size = 14
 text = "Experimental: This option will pick item from the currently visible assets  after each placement"
 autowrap_mode = 2
 
-[node name="Snapping" type="BoxContainer" parent="VBoxContainer"]
+[node name="Snapping" type="BoxContainer" parent="VBoxContainer" unique_id=22742712]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Snapping"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Snapping" unique_id=2136709588]
 layout_mode = 2
 
-[node name="GridSnappingCheckbox" type="CheckBox" parent="VBoxContainer/Snapping/VBoxContainer"]
+[node name="GridSnappingCheckbox" type="CheckBox" parent="VBoxContainer/Snapping/VBoxContainer" unique_id=42123293]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Grid Snapping"
 icon = SubResource("Texture2D_5lmt4")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Snapping/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Snapping/VBoxContainer" unique_id=251282854]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/Snapping/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/Snapping/VBoxContainer/HBoxContainer" unique_id=1964560100]
 layout_mode = 2
 text = "Grid Step"
 
-[node name="GridSnapValueSpinBox" type="SpinBox" parent="VBoxContainer/Snapping/VBoxContainer/HBoxContainer"]
+[node name="GridSnapValueSpinBox" type="SpinBox" parent="VBoxContainer/Snapping/VBoxContainer/HBoxContainer" unique_id=2046698301]
 unique_name_in_owner = true
 layout_mode = 2
 step = 0.01
 value = 1.0
 editable = false
 
-[node name="AlignNormalsCheckbox" type="CheckBox" parent="VBoxContainer"]
+[node name="AlignNormalsCheckbox" type="CheckBox" parent="VBoxContainer" unique_id=100200436]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Align Normals"
 icon = SubResource("Texture2D_5hqbk")
 
-[node name="UseAssetsOriginCheckbox" type="CheckBox" parent="VBoxContainer"]
+[node name="UseAssetsOriginCheckbox" type="CheckBox" parent="VBoxContainer" unique_id=649035029]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Use Assets Origin"
 icon = SubResource("Texture2D_dewax")
 
-[node name="FoldableContainer" type="BoxContainer" parent="VBoxContainer"]
+[node name="FoldableContainer" type="BoxContainer" parent="VBoxContainer" unique_id=2029750940]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/FoldableContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/FoldableContainer" unique_id=1484071200]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer" unique_id=1362911331]
 layout_mode = 2
 theme_override_constants/margin_top = 16
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer" unique_id=415955852]
 layout_mode = 2
 
-[node name="RandomRotationCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+[node name="RandomRotationCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer/HBoxContainer" unique_id=1831421537]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Randomize Rotation On Placement"
 icon = SubResource("Texture2D_nfir2")
 
-[node name="GridContainer" type="GridContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer" unique_id=962107204]
 layout_mode = 2
 columns = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=483932727]
 layout_mode = 2
 text = "Min"
 
-[node name="MinRotationSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
+[node name="MinRotationSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=1155708563]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -289,11 +289,11 @@ min = Vector3(-180, -180, -180)
 max = Vector3(180, 180, 180)
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="Label2" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
+[node name="Label2" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=1045841677]
 layout_mode = 2
 text = "Max"
 
-[node name="MaxRotationSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer"]
+[node name="MaxRotationSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer" unique_id=1247279541]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -301,34 +301,34 @@ min = Vector3(-180, -180, -180)
 max = Vector3(180, 180, 180)
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="MarginContainer2" type="MarginContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
+[node name="MarginContainer2" type="MarginContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer" unique_id=2099829487]
 layout_mode = 2
 theme_override_constants/margin_top = 16
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2" unique_id=463120851]
 layout_mode = 2
 
-[node name="RandomScaleCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2/HBoxContainer"]
+[node name="RandomScaleCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer/MarginContainer2/HBoxContainer" unique_id=123293372]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Randomize Scale On Placement"
 icon = SubResource("Texture2D_ik2kd")
 
-[node name="UniformScaleCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
+[node name="UniformScaleCheckBox" type="CheckBox" parent="VBoxContainer/FoldableContainer/VBoxContainer" unique_id=936425579]
 unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Unform Scaling"
 
-[node name="GridContainer2" type="GridContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer"]
+[node name="GridContainer2" type="GridContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer" unique_id=1320217043]
 layout_mode = 2
 columns = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
+[node name="Label" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=953000131]
 layout_mode = 2
 text = "Min"
 
-[node name="MinScaleSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
+[node name="MinScaleSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=1890579878]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")
@@ -337,11 +337,11 @@ max = Vector3(100, 100, 100)
 uniform = true
 metadata/_custom_type_script = "uid://btqju8qjrlawq"
 
-[node name="Label2" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
+[node name="Label2" type="Label" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=1695628357]
 layout_mode = 2
 text = "Max"
 
-[node name="MaxScaleSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2"]
+[node name="MaxScaleSelector" type="HBoxContainer" parent="VBoxContainer/FoldableContainer/VBoxContainer/GridContainer2" unique_id=768856733]
 unique_name_in_owner = true
 layout_mode = 2
 script = ExtResource("2_k4pj7")


### PR DESCRIPTION
# Pull Request

## Description

Resolves #65, resolves #90

Implements a sorting button as well as a button to change the sort to use ascending or descending order.

Making room for these buttons required making changes to the AssetPanel. I added a darker panel header to make buttons more visible. Feedback on UI would be appreciated.

The sorting methods implement ascending order, the default order, as follows:
- Name -> "A"/"a" at the top, "Z"/"z" at the bottom
- DateAdded -> Newest at the top, oldest at the bottom
- LastPlaced -> Most recently placed at the top, least recently placed on the bottom

## Type of Change

- [x] New feature

## How Has This Been Tested?
Tested in Godot.4.6.2-stable. Added demo folder and sorted by name correctly. Added custom folder with assets, and they appear at the top. Placed some rocks and they go to the top after i switch to Last Placed. 

This behaviour persist after editor restart.

## TODO:
- [x] Implement ~SortMethod.LastPlaced~ sort_by_last_placed
- [x] Implement ~SortMethod.DateAdded~ sort_by_date_added


## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally in Godot
- [x] I have updated documentation if needed
- [x] I have added relevant tests if applicable

## Additional Context

New design:

Wide view:

<img width="1282" height="506" alt="image" src="https://github.com/user-attachments/assets/26a0823e-8a9e-4837-85fa-1108a7067e8e" />

Narrow view:

<img width="854" height="510" alt="image" src="https://github.com/user-attachments/assets/308ff1a6-7caa-47cb-b6ff-585dbc22f08f" />


