### PR TITLE
feat: Save asset placer options between sessions

### DIFF
--- a/addons/asset_placer/asset_placer.gd
+++ b/addons/asset_placer/asset_placer.gd
@@ -87,7 +87,7 @@ func move_preview(mouse_position: Vector2, camera: Camera3D) -> bool:
 
 		var local_bottom = Vector3(0, preview_aabb.position.y, 0)
 
-		if _presenter.options.use_asset_origin:
+		if _options.use_asset_origin:
 			local_bottom = Vector3.ZERO
 
 		var bottom_world = new_transform * local_bottom

--- a/addons/asset_placer/asset_placer.gd
+++ b/addons/asset_placer/asset_placer.gd
@@ -19,6 +19,10 @@ var _presenter: AssetPlacerPresenter:
 	get:
 		return AssetPlacerPresenter.instance
 
+var _options: AssetPlacerOptions:
+	get:
+		return AssetPlacerPresenter.instance.options
+
 
 func _init(undo_redo: EditorUndoRedoManager):
 	self.undo_redo = undo_redo
@@ -35,7 +39,7 @@ func start_placement(root: Window, asset: AssetResource, placement: GapPlacement
 	_apply_preview_material(preview_node)
 	var selected := EditorInterface.get_selection().get_selected_nodes()
 	if selected.size() == 1 and selected[0] is Node3D:
-		AssetTransformations.apply_transforms(preview_node, _presenter.options)
+		AssetTransformations.apply_transforms(preview_node, _options)
 	self.preview_aabb = AABBProvider.provide_aabb(preview_node)
 
 
@@ -68,7 +72,7 @@ func move_preview(mouse_position: Vector2, camera: Camera3D) -> bool:
 		var hit = _strategy.get_placement_point(camera, mouse_position)
 		var normal = Vector3.UP
 
-		if _presenter.options.align_normals and hit:
+		if _options.align_normals and hit:
 			normal = hit.normal
 
 		var snapped_pos = _snap_position(hit.position, normal)
@@ -160,10 +164,10 @@ func get_collision_rids(node: Node) -> Array:
 
 
 func _snap_position(hit_pos: Vector3, normal: Vector3) -> Vector3:
-	if !_presenter.options.snapping_enabled:
+	if !_options.grid_snap_enabled:
 		return hit_pos
 
-	var grid_step: float = _presenter.options.snapping_grid_step
+	var grid_step := _options.grid_snap_step
 
 	# Build tangent basis aligned to the surface normal
 	var n := normal.normalized()
@@ -189,8 +193,7 @@ func _place_instance(transform: Transform3D, select_after_placement: bool):
 	var scene_root := _presenter.resolve_placement_parent(scene)
 	if scene_root == null:
 		return
-	var options := _presenter.options
-	var parent := AssetParentSelector.pick_parent(scene_root, asset, options.group_automatically)
+	var parent := AssetParentSelector.pick_parent(scene_root, asset, _options.group_automatically)
 
 	if is_instance_valid(parent) and is_instance_valid(asset.get_resource()):
 		var new_node: Node3D = _instantiate_asset_resource(asset)
@@ -205,7 +208,7 @@ func _place_instance(transform: Transform3D, select_after_placement: bool):
 		undo_redo.add_undo_method(self, "_undo_placement", new_node, parent)
 		undo_redo.commit_action()
 
-		AssetTransformations.apply_transforms(preview_node, _presenter.options)
+		AssetTransformations.apply_transforms(preview_node, _options)
 		_presenter.on_asset_placed()
 
 

--- a/addons/asset_placer/asset_placer.gd
+++ b/addons/asset_placer/asset_placer.gd
@@ -21,7 +21,7 @@ var _presenter: AssetPlacerPresenter:
 
 var _options: AssetPlacerOptions:
 	get:
-		return AssetPlacerPresenter.instance.options
+		return AssetPlacerOptionsManager.get_options()
 
 
 func _init(undo_redo: EditorUndoRedoManager):

--- a/addons/asset_placer/asset_placer_plugin.gd
+++ b/addons/asset_placer/asset_placer_plugin.gd
@@ -153,6 +153,8 @@ func _initialize_data_layer():
 	current_settings = settings_repository.get_settings()
 	settings_repository.settings_changed.connect(_react_to_settings_change)
 
+	AssetPlacerOptionsManager.load_options()
+
 	# TODO load library file save path setting
 	var path := AssetLibraryParser.DEFAULT_SAVE_PATH
 	AssetLibraryManager.load_asset_library(path)

--- a/addons/asset_placer/asset_placer_presenter.gd
+++ b/addons/asset_placer/asset_placer_presenter.gd
@@ -18,7 +18,9 @@ enum TransformMode { None, Rotate, Scale, Move }
 static var instance: AssetPlacerPresenter
 static var transform_step: float = 0.1
 
-var options: AssetPlacerOptions
+var options: AssetPlacerOptions:
+	get:
+		return AssetPlacerOptionsManager.get_options()
 var transform_mode: TransformMode = TransformMode.None
 var current_assets: Array[AssetResource]
 var placement_mode: GapPlacementMode = GapPlacementMode.SurfacePlacement.new():
@@ -34,7 +36,6 @@ var _selected_node: Node3D
 
 
 func _init():
-	options = AssetPlacerOptions.new()
 	options.changed.connect(_on_options_changed)
 
 	_selected_asset = null

--- a/addons/asset_placer/asset_placer_presenter.gd
+++ b/addons/asset_placer/asset_placer_presenter.gd
@@ -257,7 +257,6 @@ func move_plane_up(direction: int):
 		var step = options.snapping_grid_step if options.snapping_enabled else 0.2
 		var new_origin = plane_options.origin + plane_options.normal * (direction * step)
 
-
 		# Apply grid snapping if enabled
 		if options.snapping_enabled:
 			var normal = plane_options.normal.normalized()
@@ -267,7 +266,6 @@ func move_plane_up(direction: int):
 				* options.snapping_grid_step
 			)
 			new_origin = normal * snapped_distance
-
 
 		plane_options.origin = new_origin
 		placement_mode = GapPlacementMode.PlanePlacement.new(plane_options)

--- a/addons/asset_placer/asset_placer_presenter.gd
+++ b/addons/asset_placer/asset_placer_presenter.gd
@@ -5,7 +5,6 @@ extends RefCounted
 
 signal asset_deselected
 signal parent_changed(parent: NodePath)
-signal options_changed(options: AssetPlacerOptions)
 signal transform_mode_changed(mode: TransformMode)
 signal placement_mode_changed(mode: GapPlacementMode)
 signal preview_transform_axis_changed(axis: Vector3)
@@ -36,12 +35,13 @@ var _selected_node: Node3D
 
 func _init():
 	options = AssetPlacerOptions.new()
+	options.changed.connect(_on_options_changed)
+
 	_selected_asset = null
 	instance = self
 
 
 func ready():
-	options_changed.emit(options)
 	placement_mode_changed.emit(placement_mode)
 
 
@@ -88,38 +88,11 @@ func select_parent(node: NodePath):
 	self._parent = node
 	options.use_selected_as_parent = false
 	parent_changed.emit(node)
-	options_changed.emit(options)
-
-
-func toggle_transformation_mode(mode: TransformMode):
-	if transform_mode == mode:
-		transform_mode = TransformMode.None
-	else:
-		transform_mode = mode
-	transform_mode_changed.emit(transform_mode)
-
-	if transform_mode == TransformMode.Move:
-		_select_placement_mode(GapPlacementMode.PlanePlacement.new(_last_plane_options))
-
-	if transform_mode == TransformMode.Rotate:
-		set_random_rotation_enabled(false)
-
-	if transform_mode == TransformMode.Scale:
-		set_random_scale_enabled(false)
-
-	_select_default_axis(transform_mode)
 
 
 func clear_parent():
 	self._parent = NodePath("")
 	options.use_selected_as_parent = false
-	parent_changed.emit(_parent)
-	options_changed.emit(options)
-
-
-func set_use_selected_as_parent(value: bool):
-	options.use_selected_as_parent = value
-	options_changed.emit(options)
 	parent_changed.emit(_parent)
 
 
@@ -166,22 +139,23 @@ func _resolve_parent_from_selection() -> Node3D:
 	return picked
 
 
-func set_unform_scaling(value: bool):
-	options.uniform_scaling = value
-	if value:
-		options.min_scale = _uniform_v3(options.min_scale.x)
-		options.max_scale = _uniform_v3(options.max_scale.x)
-	options_changed.emit(options)
+func toggle_transformation_mode(mode: TransformMode):
+	if transform_mode == mode:
+		transform_mode = TransformMode.None
+	else:
+		transform_mode = mode
+	transform_mode_changed.emit(transform_mode)
 
+	if transform_mode == TransformMode.Move:
+		_select_placement_mode(GapPlacementMode.PlanePlacement.new(_last_plane_options))
 
-func set_grid_snap_value(value: float):
-	options.snapping_grid_step = value
-	options_changed.emit(options)
+	if transform_mode == TransformMode.Rotate:
+		options.use_random_rotation = false
 
+	if transform_mode == TransformMode.Scale:
+		options.use_random_scale = false
 
-func set_random_asset_enabled(value: bool):
-	options.enable_random_placement = value
-	options_changed.emit(options)
+	_select_default_axis(transform_mode)
 
 
 func toggle_axis(axis: Vector3):
@@ -204,32 +178,6 @@ func _select_axis(axis: Vector3):
 		placement_mode = GapPlacementMode.PlanePlacement.new(_last_plane_options)
 
 
-func set_random_scale_enabled(value: bool):
-	options.scale_on_placement = value
-	options_changed.emit(options)
-
-	if value and transform_mode == TransformMode.Scale:
-		toggle_transformation_mode(TransformMode.None)
-
-
-func set_random_rotation_enabled(value: bool):
-	options.rotate_on_placement = value
-	options_changed.emit(options)
-
-	if value and transform_mode == TransformMode.Rotate:
-		toggle_transformation_mode(TransformMode.None)
-
-
-func set_align_normals(value: bool):
-	options.align_normals = value
-	options_changed.emit(options)
-
-
-func set_use_asset_origin(value: bool):
-	options.use_asset_origin = value
-	options_changed.emit(options)
-
-
 func _select_default_axis(mode: TransformMode):
 	match mode:
 		TransformMode.Rotate:
@@ -242,37 +190,8 @@ func _select_default_axis(mode: TransformMode):
 			pass
 
 
-func _uniform_v3(value: float) -> Vector3:
-	return Vector3(value, value, value)
-
-
-func set_grid_snapping_enabled(value: bool):
-	options.snapping_enabled = value
-	options_changed.emit(options)
-
-
 func toggle_grid_snapping():
-	set_grid_snapping_enabled(!options.snapping_enabled)
-
-
-func set_min_rotation(vector: Vector3):
-	options.min_rotation = vector
-	options_changed.emit(options)
-
-
-func set_max_scale(vector: Vector3):
-	options.max_scale = vector
-	options_changed.emit(options)
-
-
-func set_min_scale(vector: Vector3):
-	options.min_scale = vector
-	options_changed.emit(options)
-
-
-func set_max_rotation(vector: Vector3):
-	options.max_rotation = vector
-	options_changed.emit(options)
+	options.grid_snap_enabled = not options.grid_snap_enabled
 
 
 func cancel():
@@ -318,14 +237,9 @@ func end_node_transform_mode():
 
 
 func on_asset_placed():
-	if options.enable_random_placement:
+	if options.pick_random_asset:
 		var random = current_assets.pick_random()
 		select_asset(random)
-
-
-func set_automatic_grouping(value: bool):
-	options.group_automatically = value
-	options_changed.emit(options)
 
 
 func is_node_transform_mode() -> bool:
@@ -342,6 +256,7 @@ func move_plane_up(direction: int):
 		var step = options.snapping_grid_step if options.snapping_enabled else 0.2
 		var new_origin = plane_options.origin + plane_options.normal * (direction * step)
 
+
 		# Apply grid snapping if enabled
 		if options.snapping_enabled:
 			var normal = plane_options.normal.normalized()
@@ -352,5 +267,16 @@ func move_plane_up(direction: int):
 			)
 			new_origin = normal * snapped_distance
 
+
 		plane_options.origin = new_origin
 		placement_mode = GapPlacementMode.PlanePlacement.new(plane_options)
+
+
+func _on_options_changed():
+	match transform_mode:
+		TransformMode.Scale:
+			if options.use_random_scale:
+				toggle_transformation_mode(TransformMode.None)
+		TransformMode.Rotate:
+			if options.use_random_rotation:
+				toggle_transformation_mode(TransformMode.None)

--- a/addons/asset_placer/data/asset_placer_options.gd
+++ b/addons/asset_placer/data/asset_placer_options.gd
@@ -1,21 +1,100 @@
+@tool
 class_name AssetPlacerOptions
-extends RefCounted
+extends Resource
 
-var snapping_enabled: bool = false
-var snapping_grid_step: float = 1.0
 
-var use_asset_origin: bool = true
-var align_normals: bool = false
-var enable_random_placement = false
+@export_storage var grid_snap_enabled := false: set = set_grid_snap_enabled
+@export_storage var grid_snap_step := 1.0: set = set_grid_snap_step
 
-var rotate_on_placement: bool = true
-var max_rotation: Vector3 = Vector3.UP * 180
-var min_rotation: Vector3 = Vector3.ZERO
+@export_storage var use_asset_origin := true: set = set_use_asset_origin
+@export_storage var align_normals := false: set = set_align_normals
+@export_storage var pick_random_asset := false: set = set_pick_random_asset
 
-var scale_on_placement: bool = false
-var min_scale: Vector3 = Vector3.ONE
-var max_scale: Vector3 = Vector3.ONE * 2
-var uniform_scaling: bool = true
+@export_storage var use_random_rotation := false: set = set_use_random_rotation
+@export_storage var min_random_rotation := Vector3.ZERO: set = set_min_random_rotation
+@export_storage var max_random_rotation := Vector3.UP * 180: set = set_max_random_rotation
 
-var group_automatically: bool = true
-var use_selected_as_parent: bool = false
+@export_storage var use_random_scale := false: set = set_use_random_scale
+@export_storage var min_random_scale := Vector3.ONE: set = set_min_random_scale
+@export_storage var max_random_scale := Vector3.ONE * 2: set = set_max_random_scale
+@export_storage var uniform_random_scaling := true: set = set_uniform_random_scaling
+
+@export_storage var group_automatically := true: set = set_automatic_grouping
+@export_storage var use_selected_as_parent := true: set = set_use_selected_as_parent
+
+
+func set_grid_snap_enabled(value: bool):
+	grid_snap_enabled = value
+	emit_changed()
+
+
+func set_grid_snap_step(value: float):
+	grid_snap_step = value
+	emit_changed()
+
+
+func set_use_asset_origin(value: bool):
+	use_asset_origin = value
+	emit_changed()
+
+
+func set_align_normals(value: bool):
+	align_normals = value
+	emit_changed()
+
+
+func set_pick_random_asset(value: bool):
+	pick_random_asset = value
+	emit_changed()
+
+
+func set_use_random_rotation(value: bool):
+	use_random_rotation = value
+	emit_changed()
+
+
+func set_max_random_rotation(value: Vector3):
+	max_random_rotation = value
+	emit_changed()
+
+
+func set_min_random_rotation(value: Vector3):
+	min_random_rotation = value
+	emit_changed()
+
+
+func set_use_random_scale(value: bool):
+	use_random_scale = value
+	emit_changed()
+
+
+func set_min_random_scale(value: Vector3):
+	min_random_scale = value
+	emit_changed()
+
+
+func set_max_random_scale(value: Vector3):
+	max_random_scale = value
+	emit_changed()
+
+
+func set_uniform_random_scaling(value: bool):
+	uniform_random_scaling = value
+	if value:
+		min_random_scale = _uniform_v3(min_random_scale.x)
+		max_random_scale = _uniform_v3(max_random_scale.x)
+	emit_changed()
+
+
+func set_automatic_grouping(value: bool):
+	group_automatically = value
+	emit_changed()
+
+
+func set_use_selected_as_parent(value: bool):
+	use_selected_as_parent = value
+	emit_changed()
+
+
+func _uniform_v3(value: float) -> Vector3:
+	return Vector3(value, value, value)

--- a/addons/asset_placer/data/asset_placer_options.gd
+++ b/addons/asset_placer/data/asset_placer_options.gd
@@ -2,25 +2,38 @@
 class_name AssetPlacerOptions
 extends Resource
 
+@export_storage var grid_snap_enabled := false:
+	set = set_grid_snap_enabled
+@export_storage var grid_snap_step := 1.0:
+	set = set_grid_snap_step
 
-@export_storage var grid_snap_enabled := false: set = set_grid_snap_enabled
-@export_storage var grid_snap_step := 1.0: set = set_grid_snap_step
+@export_storage var use_asset_origin := true:
+	set = set_use_asset_origin
+@export_storage var align_normals := false:
+	set = set_align_normals
+@export_storage var pick_random_asset := false:
+	set = set_pick_random_asset
 
-@export_storage var use_asset_origin := true: set = set_use_asset_origin
-@export_storage var align_normals := false: set = set_align_normals
-@export_storage var pick_random_asset := false: set = set_pick_random_asset
+@export_storage var use_random_rotation := false:
+	set = set_use_random_rotation
+@export_storage var min_random_rotation := Vector3.ZERO:
+	set = set_min_random_rotation
+@export_storage var max_random_rotation := Vector3.UP * 180:
+	set = set_max_random_rotation
 
-@export_storage var use_random_rotation := false: set = set_use_random_rotation
-@export_storage var min_random_rotation := Vector3.ZERO: set = set_min_random_rotation
-@export_storage var max_random_rotation := Vector3.UP * 180: set = set_max_random_rotation
+@export_storage var use_random_scale := false:
+	set = set_use_random_scale
+@export_storage var min_random_scale := Vector3.ONE:
+	set = set_min_random_scale
+@export_storage var max_random_scale := Vector3.ONE * 2:
+	set = set_max_random_scale
+@export_storage var uniform_random_scaling := true:
+	set = set_uniform_random_scaling
 
-@export_storage var use_random_scale := false: set = set_use_random_scale
-@export_storage var min_random_scale := Vector3.ONE: set = set_min_random_scale
-@export_storage var max_random_scale := Vector3.ONE * 2: set = set_max_random_scale
-@export_storage var uniform_random_scaling := true: set = set_uniform_random_scaling
-
-@export_storage var group_automatically := true: set = set_automatic_grouping
-@export_storage var use_selected_as_parent := true: set = set_use_selected_as_parent
+@export_storage var group_automatically := true:
+	set = set_automatic_grouping
+@export_storage var use_selected_as_parent := true:
+	set = set_use_selected_as_parent
 
 
 func set_grid_snap_enabled(value: bool):

--- a/addons/asset_placer/data/asset_placer_options_manager.gd
+++ b/addons/asset_placer/data/asset_placer_options_manager.gd
@@ -15,12 +15,25 @@ static func get_options():
 
 
 static func load_options():
-	if ResourceLoader.exists(USER_DATA_SAVE_PATH, "AssetPlacerOptions"):
-		_loaded_options = load(USER_DATA_SAVE_PATH)
-	else:
-		_loaded_options = AssetPlacerOptions.new()
+	var is_first_load := not is_instance_valid(_loaded_options)
+	if not is_first_load and is_instance_valid(_save_timer):
+		_save_options()
 
-	_loaded_options.changed.connect(_queue_save)
+	var new_options := AssetPlacerOptions.new()
+	if ResourceLoader.exists(USER_DATA_SAVE_PATH, "AssetPlacerOptions"):
+		new_options = load(USER_DATA_SAVE_PATH)
+
+	if is_first_load:
+		_loaded_options = new_options
+		_loaded_options.changed.connect(_queue_save)
+	else:
+		_loaded_options.changed.disconnect(_queue_save)
+		_move_signal_connections(new_options)
+
+		_loaded_options = new_options
+		_loaded_options.emit_changed()
+
+		_loaded_options.changed.connect(_queue_save)
 
 
 static func _queue_save():
@@ -40,3 +53,11 @@ static func _save_options():
 	_save_timer = null
 
 	ResourceSaver.save(_loaded_options, USER_DATA_SAVE_PATH)
+
+
+static func _move_signal_connections(other: AssetPlacerOptions):
+	for _signal in _loaded_options.get_signal_list():
+		for connection in _loaded_options.get_signal_connection_list(_signal["name"]):
+			_loaded_options.disconnect(_signal["name"], connection["callable"])
+			if is_instance_valid(other):
+				other.connect(_signal["name"], connection["callable"])

--- a/addons/asset_placer/data/asset_placer_options_manager.gd
+++ b/addons/asset_placer/data/asset_placer_options_manager.gd
@@ -1,0 +1,43 @@
+@tool
+class_name AssetPlacerOptionsManager
+extends RefCounted
+
+
+const USER_DATA_SAVE_PATH := "user://asset_placer_options.tres"
+## Time between AssetPlacerOptions change and save to disk in seconds.
+const TIME_TO_SAVE: float = 1.0
+
+static var _loaded_options: AssetPlacerOptions
+static var _save_timer: SceneTreeTimer
+
+
+static func get_options():
+	return _loaded_options
+
+
+static func load_options():
+	if ResourceLoader.exists(USER_DATA_SAVE_PATH, "AssetPlacerOptions"):
+		_loaded_options = load(USER_DATA_SAVE_PATH)
+	else:
+		_loaded_options = AssetPlacerOptions.new()
+
+	_loaded_options.changed.connect(_queue_save)
+
+
+static func _queue_save():
+	if is_instance_valid(_save_timer):
+		_save_timer.time_left = TIME_TO_SAVE
+		return
+
+	var mainloop := Engine.get_main_loop()
+	assert(mainloop is SceneTree)
+
+	_save_timer = (mainloop as SceneTree).create_timer(TIME_TO_SAVE)
+	_save_timer.timeout.connect(_save_options)
+
+
+static func _save_options():
+	_save_timer.timeout.disconnect(_save_options)
+	_save_timer = null
+
+	ResourceSaver.save(_loaded_options, USER_DATA_SAVE_PATH)

--- a/addons/asset_placer/data/asset_placer_options_manager.gd
+++ b/addons/asset_placer/data/asset_placer_options_manager.gd
@@ -2,7 +2,6 @@
 class_name AssetPlacerOptionsManager
 extends RefCounted
 
-
 const USER_DATA_SAVE_PATH := "user://asset_placer_options.tres"
 ## Time between AssetPlacerOptions change and save to disk in seconds.
 const TIME_TO_SAVE: float = 1.0

--- a/addons/asset_placer/data/asset_placer_options_manager.gd.uid
+++ b/addons/asset_placer/data/asset_placer_options_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://clf05yk6ldins

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
@@ -89,7 +89,7 @@ func _show_terrain_3d_selector():
 
 
 func show_parent(parent: NodePath):
-	if presenter.options.use_selected_as_parent:
+	if options.use_selected_as_parent:
 		parent_button.disabled = true
 		parent_button.text = "From selection"
 		parent_button.icon = EditorIconTexture2D.new("Node3D")

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
@@ -2,6 +2,9 @@
 extends Control
 
 var presenter: AssetPlacerPresenter
+var options: AssetPlacerOptions:
+	get:
+		return presenter.options
 @onready var grid_snapping_checkbox = %GridSnappingCheckbox
 @onready var grid_snap_value_spin_box: SpinBox = %GridSnapValueSpinBox
 @onready var min_rotation_selector: SpinBoxVector3 = %MinRotationSelector
@@ -27,7 +30,7 @@ var presenter: AssetPlacerPresenter
 
 func _ready():
 	presenter = AssetPlacerPresenter.instance
-	presenter.options_changed.connect(set_options)
+	options.changed.connect(set_options)
 	presenter.parent_changed.connect(show_parent)
 	presenter.placement_mode_changed.connect(show_placement_mode)
 
@@ -42,17 +45,23 @@ func _ready():
 					_show_terrain_3d_selector()
 	)
 
-	grid_snapping_checkbox.toggled.connect(presenter.set_grid_snapping_enabled)
-	grid_snap_value_spin_box.value_changed.connect(presenter.set_grid_snap_value)
-	random_asset_check_box.toggled.connect(presenter.set_random_asset_enabled)
-	max_rotation_selector.value_changed.connect(presenter.set_max_rotation)
-	min_rotation_selector.value_changed.connect(presenter.set_min_rotation)
-	min_scale_selector.value_changed.connect(presenter.set_min_scale)
-	max_scale_selector.value_changed.connect(presenter.set_max_scale)
-	uniform_scale_check_box.toggled.connect(presenter.set_unform_scaling)
-	use_assets_origin_checkbox.toggled.connect(presenter.set_use_asset_origin)
-	group_automatically_check_box.toggled.connect(presenter.set_automatic_grouping)
-	use_selection_for_parent_check_box.toggled.connect(presenter.set_use_selected_as_parent)
+	grid_snapping_checkbox.toggled.connect(options.set_grid_snap_enabled)
+	grid_snap_value_spin_box.value_changed.connect(options.set_grid_snap_step)
+	random_asset_check_box.toggled.connect(options.set_pick_random_asset)
+
+	random_rotation_check_box.toggled.connect(options.set_use_random_rotation)
+	max_rotation_selector.value_changed.connect(options.set_max_random_rotation)
+	min_rotation_selector.value_changed.connect(options.set_min_random_rotation)
+
+	random_scale_check_box.toggled.connect(options.set_use_random_scale)
+	min_scale_selector.value_changed.connect(options.set_min_random_scale)
+	max_scale_selector.value_changed.connect(options.set_max_random_scale)
+	uniform_scale_check_box.toggled.connect(options.set_uniform_random_scaling)
+
+	use_assets_origin_checkbox.toggled.connect(options.set_use_asset_origin)
+	group_automatically_check_box.toggled.connect(options.set_automatic_grouping)
+	use_selection_for_parent_check_box.toggled.connect(options.set_use_selected_as_parent)
+	align_normals_checkbox.toggled.connect(options.set_align_normals)
 
 	plane_axis_spin_box.value_changed.connect(
 		func(normal: Vector3):
@@ -66,13 +75,13 @@ func _ready():
 			presenter.placement_mode = GapPlacementMode.PlanePlacement.new(plane)
 	)
 
+
+
 	parent_button.pressed.connect(
 		func(): EditorInterface.popup_node_selector(presenter.select_parent, [&"Node3D"])
 	)
 
-	random_rotation_check_box.toggled.connect(presenter.set_random_rotation_enabled)
-	random_scale_check_box.toggled.connect(presenter.set_random_scale_enabled)
-	align_normals_checkbox.toggled.connect(presenter.set_align_normals)
+	set_options()
 	presenter.ready()
 
 
@@ -118,20 +127,23 @@ func show_placement_mode(mode: GapPlacementMode):
 		placement_mode_options_button.select(2)
 
 
-func set_options(options: AssetPlacerOptions):
-	random_asset_check_box.set_pressed_no_signal(options.enable_random_placement)
-	grid_snapping_checkbox.set_pressed_no_signal(options.snapping_enabled)
-	grid_snap_value_spin_box.editable = options.snapping_enabled
-	grid_snap_value_spin_box.set_value_no_signal(options.snapping_grid_step)
-	max_rotation_selector.set_value_no_signal(options.max_rotation)
-	min_rotation_selector.set_value_no_signal(options.min_rotation)
-	min_scale_selector.set_value_no_signal(options.min_scale)
-	max_scale_selector.set_value_no_signal(options.max_scale)
-	min_scale_selector.uniform = options.uniform_scaling
-	max_scale_selector.uniform = options.uniform_scaling
-	uniform_scale_check_box.set_pressed_no_signal(options.uniform_scaling)
-	random_rotation_check_box.set_pressed_no_signal(options.rotate_on_placement)
-	random_scale_check_box.set_pressed_no_signal(options.scale_on_placement)
+func set_options():
+	grid_snapping_checkbox.set_pressed_no_signal(options.grid_snap_enabled)
+	grid_snap_value_spin_box.editable = options.grid_snap_enabled
+	grid_snap_value_spin_box.set_value_no_signal(options.grid_snap_step)
+	random_asset_check_box.set_pressed_no_signal(options.pick_random_asset)
+
+	random_scale_check_box.set_pressed_no_signal(options.use_random_scale)
+	min_scale_selector.set_value_no_signal(options.min_random_scale)
+	max_scale_selector.set_value_no_signal(options.max_random_scale)
+	min_scale_selector.uniform = options.uniform_random_scaling
+	max_scale_selector.uniform = options.uniform_random_scaling
+	uniform_scale_check_box.set_pressed_no_signal(options.uniform_random_scaling)
+
+	random_rotation_check_box.set_pressed_no_signal(options.use_random_rotation)
+	max_rotation_selector.set_value_no_signal(options.max_random_rotation)
+	min_rotation_selector.set_value_no_signal(options.min_random_rotation)
+
 	align_normals_checkbox.set_pressed_no_signal(options.align_normals)
 	use_assets_origin_checkbox.set_pressed_no_signal(options.use_asset_origin)
 	group_automatically_check_box.set_pressed_no_signal(options.group_automatically)

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
@@ -4,7 +4,8 @@ extends Control
 var presenter: AssetPlacerPresenter
 var options: AssetPlacerOptions:
 	get:
-		return presenter.options
+		return AssetPlacerOptionsManager.get_options()
+
 @onready var grid_snapping_checkbox = %GridSnappingCheckbox
 @onready var grid_snap_value_spin_box: SpinBox = %GridSnapValueSpinBox
 @onready var min_rotation_selector: SpinBoxVector3 = %MinRotationSelector

--- a/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
+++ b/addons/asset_placer/ui/asset_placer_options/asset_placer_options.gd
@@ -76,8 +76,6 @@ func _ready():
 			presenter.placement_mode = GapPlacementMode.PlanePlacement.new(plane)
 	)
 
-
-
 	parent_button.pressed.connect(
 		func(): EditorInterface.popup_node_selector(presenter.select_parent, [&"Node3D"])
 	)

--- a/addons/asset_placer/ui/viewport_overlay/viewport_overlay.gd
+++ b/addons/asset_placer/ui/viewport_overlay/viewport_overlay.gd
@@ -24,18 +24,23 @@ func _ready():
 	_error_position = error_container.position
 	show_settings(_settings_repository.get_settings())
 	_settings_repository.settings_changed.connect(show_settings)
-	var viewport_size = get_viewport_rect().size
+
+	var viewport_size := get_viewport_rect().size
 	_error_hidden_position = Vector2(-viewport_size.x, _error_position.y)
 	error_container.position = _error_hidden_position
-	var presenter = AssetPlacerPresenter.instance
+	error_timer.timeout.connect(hide_error)
+
+	var presenter := AssetPlacerPresenter.instance
 	presenter.transform_mode_changed.connect(set_mode)
 	presenter.preview_transform_axis_changed.connect(set_axis)
 	presenter.placer_active.connect(_set_overlay_visible)
 	presenter.placement_mode_changed.connect(set_placement_mode)
-	presenter.options_changed.connect(show_options)
-	presenter.ready()
 	presenter.show_error.connect(show_error)
-	error_timer.timeout.connect(hide_error)
+	presenter.ready()
+
+	presenter.options.changed.connect(show_options)
+	show_options()
+
 	set_mode(presenter.transform_mode)
 	set_axis(presenter.preview_transform_axis)
 
@@ -87,8 +92,9 @@ func show_settings(settings: AssetPlacerSettings):
 	)
 
 
-func show_options(options: AssetPlacerOptions):
-	snapping_switch.button_pressed = options.snapping_enabled
+func show_options():
+	var options := AssetPlacerPresenter._instance.options
+	snapping_switch.button_pressed = options.grid_snap_enabled
 
 
 func set_axis(vector: Vector3):

--- a/addons/asset_placer/ui/viewport_overlay/viewport_overlay.gd
+++ b/addons/asset_placer/ui/viewport_overlay/viewport_overlay.gd
@@ -38,7 +38,7 @@ func _ready():
 	presenter.show_error.connect(show_error)
 	presenter.ready()
 
-	presenter.options.changed.connect(show_options)
+	AssetPlacerOptionsManager.get_options().changed.connect(show_options)
 	show_options()
 
 	set_mode(presenter.transform_mode)
@@ -93,8 +93,7 @@ func show_settings(settings: AssetPlacerSettings):
 
 
 func show_options():
-	var options := AssetPlacerPresenter._instance.options
-	snapping_switch.button_pressed = options.grid_snap_enabled
+	snapping_switch.button_pressed = AssetPlacerOptionsManager.get_options().grid_snap_enabled
 
 
 func set_axis(vector: Vector3):

--- a/addons/asset_placer/utils/transformations.gd
+++ b/addons/asset_placer/utils/transformations.gd
@@ -8,34 +8,34 @@ static func apply_transforms(node: Node3D, options: AssetPlacerOptions):
 
 
 static func transform_rotation(transform: Transform3D, options: AssetPlacerOptions) -> Transform3D:
-	if not options.rotate_on_placement:
+	if not options.use_random_rotation:
 		return transform
 
-	var rx = randf_range(options.min_rotation.x, options.max_rotation.x)
+	var rx := randf_range(options.min_random_rotation.x, options.max_random_rotation.x)
 	transform = transform.rotated(Vector3(1, 0, 0), deg_to_rad(rx))
-	var ry = randf_range(options.min_rotation.y, options.max_rotation.y)
+	var ry := randf_range(options.min_random_rotation.y, options.max_random_rotation.y)
 	transform = transform.rotated(Vector3(0, 1, 0), deg_to_rad(ry))
-	var rz = randf_range(options.min_rotation.z, options.max_rotation.z)
+	var rz := randf_range(options.min_random_rotation.z, options.max_random_rotation.z)
 	transform = transform.rotated(Vector3(0, 0, 1), deg_to_rad(rz))
 	return transform
 
 
 static func transform_scale(transform: Transform3D, options: AssetPlacerOptions) -> Transform3D:
-	if not options.scale_on_placement:
+	if not options.use_random_scale:
 		return transform
 
-	if options.uniform_scaling:
-		var scale = randf_range(options.min_scale.x, options.max_scale.x)
-		var basiz = transform.basis.orthonormalized().scaled(Vector3(scale, scale, scale))
-		transform.basis = basiz
+	if options.uniform_random_scaling:
+		var scale := randf_range(options.min_random_scale.x, options.max_random_scale.x)
+		var basis := transform.basis.orthonormalized().scaled(Vector3(scale, scale, scale))
+		transform.basis = basis
 		return transform
-	else:
-		var scale_x = randf_range(options.min_scale.x, options.max_scale.x)
-		var scale_y = randf_range(options.min_scale.y, options.max_scale.y)
-		var scale_z = randf_range(options.min_scale.z, options.max_scale.z)
-		var basiz = transform.basis.orthonormalized().scaled(Vector3(scale_x, scale_y, scale_z))
-		transform.basis = basiz
-		return transform
+
+	var scale_x := randf_range(options.min_random_scale.x, options.max_random_scale.x)
+	var scale_y := randf_range(options.min_random_scale.y, options.max_random_scale.y)
+	var scale_z := randf_range(options.min_random_scale.z, options.max_random_scale.z)
+	var basis := transform.basis.orthonormalized().scaled(Vector3(scale_x, scale_y, scale_z))
+	transform.basis = basis
+	return transform
 
 
 static func make_uniform(v: Vector3) -> Vector3:


### PR DESCRIPTION
# Pull Request

## Description

This PR changes AssetPlacerOptions into a resource so it can be easily saved. It also changes the name of some of its properties to be more clear.

This PR is also fitting to change the default options of AssetPlacerOptions.

## Related Issue

Resolves #82 

## Type of Change

- [x] New feature
- [x] Code refactor

## How Has This Been Tested?

Changing options in the options panel stay the same when reloading the editor.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally in Godot
- [x] I have updated documentation if needed
- [x] I have added relevant tests if applicable

