### PR TITLE
Fix about window overflowing when made small

### DIFF
--- a/addons/asset_placer/ui/about/about_window.tscn
+++ b/addons/asset_placer/ui/about/about_window.tscn
@@ -32,14 +32,16 @@ script = ExtResource("2_r5xs8")
 icon_name = &"Debug"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
-[node name="AboutWindow" type="Control" unique_id=1921387020]
-layout_mode = 3
+[node name="AboutWindow" type="MarginContainer" unique_id=2094620722]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_namxt")
+
+[node name="Panel" type="Panel" parent="." unique_id=1237872375]
+layout_mode = 2
 
 [node name="UpdatePopup" type="PopupPanel" parent="." unique_id=788300311]
 oversampling_override = 1.0
@@ -120,39 +122,33 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Apply Update and Restart"
 
-[node name="Panel" type="Panel" parent="." unique_id=339192573]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="CenterContainer" type="CenterContainer" parent="Panel" unique_id=1342642714]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="HBoxContainer" type="VBoxContainer" parent="Panel/CenterContainer" unique_id=1111038844]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=385866275]
 layout_mode = 2
+theme_override_constants/margin_top = -16
+
+[node name="CenterContainer" type="CenterContainer" parent="MarginContainer" unique_id=1342642714]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/CenterContainer" unique_id=1111038844]
+layout_mode = 2
+theme_override_constants/separation = 0
 alignment = 1
 
-[node name="Label" type="Label" parent="Panel/CenterContainer/HBoxContainer" unique_id=2025837285]
+[node name="Label" type="Label" parent="MarginContainer/CenterContainer/VBoxContainer" unique_id=2025837285]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 48
 text = "Asset Placer"
 
-[node name="VersionLabel" type="Label" parent="Panel/CenterContainer/HBoxContainer" unique_id=1221704459]
+[node name="VersionLabel" type="Label" parent="MarginContainer/CenterContainer/VBoxContainer" unique_id=1221704459]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
-text = "Version 1.4.0"
+text = "Version 1.5.0-alpha2"
 
-[node name="UpdateButton" type="Button" parent="Panel/CenterContainer/HBoxContainer" unique_id=133643675]
+[node name="UpdateButton" type="Button" parent="MarginContainer/CenterContainer/VBoxContainer" unique_id=133643675]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -161,26 +157,26 @@ theme_override_constants/h_separation = 4
 text = "Version 1.1.5 Availalbe"
 icon = SubResource("Texture2D_4v60v")
 
-[node name="Space" type="Control" parent="Panel/CenterContainer/HBoxContainer" unique_id=1130040503]
-custom_minimum_size = Vector2(0, 64)
+[node name="Space" type="Control" parent="MarginContainer/CenterContainer/VBoxContainer" unique_id=1130040503]
+custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Panel/CenterContainer/HBoxContainer" unique_id=1821612903]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/CenterContainer/VBoxContainer" unique_id=1821612903]
 layout_mode = 2
-theme_override_constants/separation = 16
+theme_override_constants/separation = 12
 alignment = 1
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer" unique_id=620198924]
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer" unique_id=620198924]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="TextureRect" type="TextureRect" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer3" unique_id=1986662026]
+[node name="TextureRect" type="TextureRect" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer3" unique_id=1986662026]
 layout_mode = 2
 texture = ExtResource("3_vijnu")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="DiscordLinkButton" type="LinkButton" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer3" unique_id=478282305]
+[node name="DiscordLinkButton" type="LinkButton" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer3" unique_id=478282305]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -188,68 +184,56 @@ size_flags_vertical = 3
 text = "Join our Discord"
 uri = "https://discord.gg/UyYCp53Hym"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer" unique_id=672040414]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer" unique_id=672040414]
 layout_mode = 2
 alignment = 1
 
-[node name="Label2" type="Label" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer" unique_id=916920657]
+[node name="Label2" type="Label" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer" unique_id=916920657]
 layout_mode = 2
 text = "Enjoying this Plugin? Please consider leaving a Star on "
 
-[node name="Label3" type="LinkButton" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer" unique_id=772806341]
+[node name="Label3" type="LinkButton" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer" unique_id=772806341]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 text = "GitHub"
 uri = "https://github.com/levinzonr/godot-asset-placer"
 
-[node name="TextureRect" type="TextureRect" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer" unique_id=1039292615]
+[node name="TextureRect" type="TextureRect" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer" unique_id=1039292615]
 layout_mode = 2
 texture = SubResource("Texture2D_vijnu")
 stretch_mode = 3
 
-[node name="Label" type="Label" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer" unique_id=1801033334]
-layout_mode = 2
-text = "Or"
-horizontal_alignment = 1
-
-[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer" unique_id=967098558]
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer" unique_id=967098558]
 layout_mode = 2
 size_flags_vertical = 3
+theme_override_constants/separation = 35
 alignment = 1
 
-[node name="CenterContainer" type="BoxContainer" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer2" unique_id=403765861]
+[node name="CenterContainer" type="BoxContainer" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2" unique_id=403765861]
 layout_mode = 2
 size_flags_horizontal = 3
+alignment = 2
 
-[node name="FeatureRequestButton" type="Button" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer2/CenterContainer" unique_id=908618622]
+[node name="FeatureRequestButton" type="Button" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2/CenterContainer" unique_id=908618622]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Missing Feature?"
 icon = SubResource("Texture2D_r5xs8")
 alignment = 0
 
-[node name="CenterContainer2" type="BoxContainer" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer2" unique_id=552566354]
+[node name="Label" type="Label" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2" unique_id=1801033334]
+layout_mode = 2
+text = "Or"
+horizontal_alignment = 1
+
+[node name="CenterContainer2" type="BoxContainer" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2" unique_id=552566354]
 layout_mode = 2
 size_flags_horizontal = 3
-alignment = 2
 
-[node name="IssueButton" type="Button" parent="Panel/CenterContainer/HBoxContainer/VBoxContainer/HBoxContainer2/CenterContainer2" unique_id=746174359]
+[node name="IssueButton" type="Button" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2/CenterContainer2" unique_id=746174359]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Spotted Bug / Issue?"
 icon = SubResource("Texture2D_tt7kp")
 alignment = 0
-
-[node name="MarginContainer" type="MarginContainer" parent="Panel" unique_id=1318635393]
-layout_mode = 1
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -123.0
-offset_bottom = 40.0
-grow_horizontal = 0
-theme_override_constants/margin_left = 12
-theme_override_constants/margin_top = 12
-theme_override_constants/margin_right = 12
-theme_override_constants/margin_bottom = 12

--- a/addons/asset_placer/ui/about/about_window.tscn
+++ b/addons/asset_placer/ui/about/about_window.tscn
@@ -181,6 +181,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 3
+tooltip_text = "https://discord.gg/UyYCp53Hym"
 text = "Join our Discord"
 uri = "https://discord.gg/UyYCp53Hym"
 
@@ -190,12 +191,13 @@ alignment = 1
 
 [node name="Label2" type="Label" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer" unique_id=916920657]
 layout_mode = 2
-text = "Enjoying this Plugin? Please consider leaving a Star on "
+text = "Enjoying this Plugin? Please consider leaving a Star on"
 
 [node name="Label3" type="LinkButton" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer" unique_id=772806341]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+tooltip_text = "https://github.com/levinzonr/godot-asset-placer"
 text = "GitHub"
 uri = "https://github.com/levinzonr/godot-asset-placer"
 
@@ -218,6 +220,7 @@ alignment = 2
 [node name="FeatureRequestButton" type="Button" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2/CenterContainer" unique_id=908618622]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Create a feature request on Github"
 text = "Missing Feature?"
 icon = SubResource("Texture2D_r5xs8")
 alignment = 0
@@ -234,6 +237,7 @@ size_flags_horizontal = 3
 [node name="IssueButton" type="Button" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer2/CenterContainer2" unique_id=746174359]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Create a bug report on Github"
 text = "Spotted Bug / Issue?"
 icon = SubResource("Texture2D_tt7kp")
 alignment = 0

--- a/addons/asset_placer/ui/about/about_window.tscn
+++ b/addons/asset_placer/ui/about/about_window.tscn
@@ -170,10 +170,23 @@ alignment = 1
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="TextureRect" type="TextureRect" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer3" unique_id=1986662026]
+[node name="Control" type="Control" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer3" unique_id=990267933]
 layout_mode = 2
+
+[node name="TextureRect" type="TextureRect" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer3/Control" unique_id=1986662026]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -32.0
+offset_top = -15.5
+offset_bottom = 16.499996
+grow_horizontal = 0
+grow_vertical = 2
 texture = ExtResource("3_vijnu")
-expand_mode = 2
+expand_mode = 1
 stretch_mode = 5
 
 [node name="DiscordLinkButton" type="LinkButton" parent="MarginContainer/CenterContainer/VBoxContainer/VBoxContainer/HBoxContainer3" unique_id=478282305]


### PR DESCRIPTION
# Pull Request

## Description

Fixes #91

Makes the About window's content much smaller so it can fit in the dock without overflowing.
Also added some helpful tooltips for the links and buttons in the About window.


## Type of Change

- [x] Visual fix

## How Has This Been Tested?
Tested on 4.6.2-stable and 4.4-stable

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally in Godot
- [x] I have updated documentation if needed
- [x] I have added relevant tests if applicable

## Additional Context

<img width="1093" height="355" alt="image" src="https://github.com/user-attachments/assets/07b8462f-89f2-4141-8df7-1885a5dfb8ef" />