### PR TITLE
Feat: Add setting to change asset library path

### DIFF
--- a/addons/asset_placer/asset_placer_plugin.gd
+++ b/addons/asset_placer/asset_placer_plugin.gd
@@ -157,9 +157,7 @@ func _initialize_data_layer():
 
 	APEditorSettingsManager.load_editor_settings()
 
-	# TODO load library file save path setting
-	var path := AssetLibraryParser.DEFAULT_SAVE_PATH
-	AssetLibraryManager.load_asset_library(path)
+	AssetLibraryManager.load_asset_library(current_settings.asset_library_path)
 
 
 func _react_to_settings_change(settings: AssetPlacerSettings):

--- a/addons/asset_placer/asset_placer_plugin.gd
+++ b/addons/asset_placer/asset_placer_plugin.gd
@@ -153,6 +153,7 @@ func _initialize_data_layer():
 	settings_repository = AssetPlacerSettingsRepository.new()
 	current_settings = settings_repository.get_settings()
 	settings_repository.settings_changed.connect(_react_to_settings_change)
+	settings_repository.initialize_project_settings(current_settings)
 
 	APEditorSettingsManager.load_editor_settings()
 

--- a/addons/asset_placer/data/asset_library_manager.gd
+++ b/addons/asset_placer/data/asset_library_manager.gd
@@ -17,6 +17,31 @@ static func get_asset_library() -> AssetLibrary:
 	return _asset_library
 
 
+static func update_save_path(new_path: String):
+	assert(new_path.is_absolute_path(), "Cannot use non-absolute asset library path %s" % new_path)
+	if new_path == _save_path:
+		return
+
+	if is_instance_valid(_save_timer):
+		_save_asset_library()
+
+	if FileAccess.file_exists(new_path):
+		var msg := "Asset Placer: Existing Asset Library found at %s, loading new library. " + \
+			"The old library can still be found at %s"
+		print(msg % [new_path, _save_path])
+		_save_path = new_path
+		load_asset_library(new_path)
+
+	else:
+		var msg := (
+			"Asset Placer: Copying Asset Library to new path %s. " +
+			"The old library can still be found at %s"
+		)
+		print(msg % [new_path, _save_path])
+		_save_path = new_path
+		_save_asset_library()
+
+
 static func load_asset_library(load_path: String) -> void:
 	if is_instance_valid(_save_timer):
 		_save_asset_library()
@@ -47,8 +72,9 @@ static func free_library():
 
 
 static func _save_asset_library():
-	_save_timer.timeout.disconnect(_save_asset_library)
-	_save_timer = null
+	if is_instance_valid(_save_timer):
+		_save_timer.timeout.disconnect(_save_asset_library)
+		_save_timer = null
 
 	assert(is_instance_valid(_asset_library), "Cannot save AssetLibrary when none is loaded.")
 

--- a/addons/asset_placer/data/asset_library_manager.gd
+++ b/addons/asset_placer/data/asset_library_manager.gd
@@ -26,16 +26,18 @@ static func update_save_path(new_path: String):
 		_save_asset_library()
 
 	if FileAccess.file_exists(new_path):
-		var msg := "Asset Placer: Existing Asset Library found at %s, loading new library. " + \
-			"The old library can still be found at %s"
+		var msg := (
+			"Asset Placer: Existing Asset Library found at %s, loading new library. "
+			+ "The old library can still be found at %s"
+		)
 		print(msg % [new_path, _save_path])
 		_save_path = new_path
 		load_asset_library(new_path)
 
 	else:
 		var msg := (
-			"Asset Placer: Copying Asset Library to new path %s. " +
-			"The old library can still be found at %s"
+			"Asset Placer: Copying Asset Library to new path %s. "
+			+ "The old library can still be found at %s"
 		)
 		print(msg % [new_path, _save_path])
 		_save_path = new_path

--- a/addons/asset_placer/data/asset_placer_settings.gd
+++ b/addons/asset_placer/data/asset_placer_settings.gd
@@ -1,10 +1,6 @@
 class_name AssetPlacerSettings
 extends RefCounted
 
-const DEFAULT_PREVIEW_MATERIAL := "res://addons/asset_placer/utils/preview_material.tres"
-const DEFAULT_PLANE_MATERIAL := "res://addons/asset_placer/ui/plane_preview/plane_preview_material.tres"
-const DEFAULT_ASSET_LIBRARY_PATH := AssetLibraryParser.DEFAULT_SAVE_PATH
-
 enum Bindings {
 	Rotate,
 	Scale,
@@ -20,6 +16,10 @@ enum Bindings {
 }
 
 enum UpdateChannel { Stable, Beta, Alpha }
+
+const DEFAULT_PREVIEW_MATERIAL := "res://addons/asset_placer/utils/preview_material.tres"
+const DEFAULT_PLANE_MATERIAL := "res://addons/asset_placer/ui/plane_preview/plane_preview_material.tres"
+const DEFAULT_ASSET_LIBRARY_PATH := AssetLibraryParser.DEFAULT_SAVE_PATH
 
 var transform_step: float
 var rotation_step: float

--- a/addons/asset_placer/data/asset_placer_settings.gd
+++ b/addons/asset_placer/data/asset_placer_settings.gd
@@ -1,6 +1,10 @@
 class_name AssetPlacerSettings
 extends RefCounted
 
+const DEFAULT_PREVIEW_MATERIAL := "res://addons/asset_placer/utils/preview_material.tres"
+const DEFAULT_PLANE_MATERIAL := "res://addons/asset_placer/ui/plane_preview/plane_preview_material.tres"
+const DEFAULT_ASSET_LIBRARY_PATH := AssetLibraryParser.DEFAULT_SAVE_PATH
+
 enum Bindings {
 	Rotate,
 	Scale,
@@ -19,11 +23,8 @@ enum UpdateChannel { Stable, Beta, Alpha }
 
 var transform_step: float
 var rotation_step: float
-var preview_material_resource: String
-var plane_material_resource: String
 var bindings: Dictionary
 var ui_scale: float
-var asset_library_path: String
 var update_channel: UpdateChannel
 var binding_positive_transform: APInputOption:
 	get():
@@ -31,6 +32,11 @@ var binding_positive_transform: APInputOption:
 var binding_negative_transform: APInputOption:
 	get():
 		return bindings[Bindings.TransformNegative]
+
+# Project Settings
+var preview_material_resource := DEFAULT_PREVIEW_MATERIAL
+var plane_material_resource := DEFAULT_PLANE_MATERIAL
+var asset_library_path := DEFAULT_ASSET_LIBRARY_PATH
 
 
 static func default() -> AssetPlacerSettings:
@@ -52,11 +58,10 @@ static func default() -> AssetPlacerSettings:
 	settings.bindings[Bindings.ToggleAxisY] = APInputOption.key_press(Key.KEY_Y)
 	settings.bindings[Bindings.ToggleAxisZ] = APInputOption.key_press(Key.KEY_Z)
 	settings.bindings[Bindings.TogglePlaneMode] = APInputOption.key_press(Key.KEY_Q)
-	settings.preview_material_resource = "res://addons/asset_placer/utils/preview_material.tres"
-	settings.plane_material_resource = ("res://addons/asset_placer/ui/plane_preview/plane_preview_material.tres")
+
 	settings.transform_step = 0.1
 	settings.rotation_step = 5
 	settings.ui_scale = 1.0
-	settings.asset_library_path = "user://asset_library.json"
 	settings.update_channel = UpdateChannel.Stable
+
 	return settings

--- a/addons/asset_placer/data/asset_placer_settings_repository.gd
+++ b/addons/asset_placer/data/asset_placer_settings_repository.gd
@@ -4,14 +4,17 @@ extends RefCounted
 signal settings_changed(settings: AssetPlacerSettings)
 
 const KEY_BASE = "asset_placer/%s"
-const KEY_BINDING_SCALE: String = "bindings/scale_asset"
 const KEY_TRANSFORM_STEP: String = "general/transform_step_normal"
 const KEY_ROTATION_STEP: String = "general/rotation_step_normal"
+const KEY_UI_SCALE: String = "general/ui_scale"
+const KEY_UPDATE_CHANNEL: String = "general/update_channel"
+const KEY_MANAGE_COLLECTIONS_DIALOG_SIZE: String = "ui/manage_collections_dialog_size"
+
+# Keybinds
+const KEY_BINDING_SCALE: String = "bindings/scale_asset"
 const KEY_BINDING_ROTATE: String = "bindings/rotate_asset"
 const KEY_BINDING_TRANSLATE: String = "bindings/translate_asset"
 const KEY_BINDING_GRID_SNAP: String = "bindings/grid_snapping"
-const KEY_GENERAL_PREVIEW_MATERIAL: String = "general/preview_material"
-const KEY_GENERAL_PLANE_MATERIAL: String = "general/plane_material"
 const KEY_BINDING_IN_PLACE_TRANSFORM: String = "bindings/in_place_transform"
 const KEY_BINDING_TRANSFORM_POSITIVE: String = "bindings/positive_transform"
 const KEY_BINDING_TRANSFORM_NEGATIVE: String = "bindings/negative_transform"
@@ -19,10 +22,6 @@ const KEY_BINDING_TOGGLE_AXIS_X: String = "bindings/toggle_axis_x"
 const KEY_BINDING_TOGGLE_AXIS_Y: String = "bindings/toggle_axis_y"
 const KEY_BINDING_TOGGLE_AXIS_Z: String = "bindings/toggle_axis_z"
 const KEY_BINDING_TOGGLE_PLANE_MODE: String = "bindings/toggle_plane_mode"
-const KEY_UI_SCALE: String = "general/ui_scale"
-const KEY_ASSET_LIBRARY_PATH: String = "general/asset_library_path"
-const KEY_UPDATE_CHANNEL: String = "general/update_channel"
-const KEY_MANAGE_COLLECTIONS_DIALOG_SIZE: String = "ui/manage_collections_dialog_size"
 const _BINDING_KEYS := {
 	AssetPlacerSettings.Bindings.Rotate: KEY_BINDING_ROTATE,
 	AssetPlacerSettings.Bindings.Scale: KEY_BINDING_SCALE,
@@ -36,6 +35,11 @@ const _BINDING_KEYS := {
 	AssetPlacerSettings.Bindings.ToggleAxisZ: KEY_BINDING_TOGGLE_AXIS_Z,
 	AssetPlacerSettings.Bindings.TogglePlaneMode: KEY_BINDING_TOGGLE_PLANE_MODE,
 }
+
+# Project Settings
+const KEY_GENERAL_PREVIEW_MATERIAL: String = "general/preview_material"
+const KEY_GENERAL_PLANE_MATERIAL: String = "general/plane_material"
+const KEY_ASSET_LIBRARY_PATH: String = "general/asset_library_path"
 
 static var instance: AssetPlacerSettingsRepository
 
@@ -54,6 +58,16 @@ func _get_binding_storage_key(binding: AssetPlacerSettings.Bindings) -> String:
 	return ""
 
 
+func initialize_project_settings(settings: AssetPlacerSettings):
+	_set_project_setting(KEY_GENERAL_PREVIEW_MATERIAL, settings.preview_material_resource)
+	_set_project_setting(KEY_GENERAL_PLANE_MATERIAL, settings.plane_material_resource)
+	_set_project_setting(KEY_ASSET_LIBRARY_PATH, settings.asset_library_path)
+
+	_set_project_setting_default(KEY_GENERAL_PREVIEW_MATERIAL, settings.DEFAULT_PREVIEW_MATERIAL)
+	_set_project_setting_default(KEY_GENERAL_PLANE_MATERIAL, settings.DEFAULT_PLANE_MATERIAL)
+	_set_project_setting_default(KEY_ASSET_LIBRARY_PATH, settings.DEFAULT_ASSET_LIBRARY_PATH)
+
+
 func set_settings(settings: AssetPlacerSettings):
 	var current = get_settings()
 
@@ -66,13 +80,15 @@ func set_settings(settings: AssetPlacerSettings):
 		if not storage_key.is_empty():
 			_set_editor_setting(storage_key, settings.bindings[binding].serialize())
 
-	_set_project_setting(KEY_GENERAL_PREVIEW_MATERIAL, settings.preview_material_resource)
-	_set_project_setting(KEY_GENERAL_PLANE_MATERIAL, settings.plane_material_resource)
 	_set_editor_setting(KEY_TRANSFORM_STEP, settings.transform_step)
 	_set_editor_setting(KEY_ROTATION_STEP, settings.rotation_step)
 	_set_editor_setting(KEY_UI_SCALE, settings.ui_scale)
 	_set_editor_setting(KEY_UPDATE_CHANNEL, settings.update_channel)
+
+	_set_project_setting(KEY_GENERAL_PREVIEW_MATERIAL, settings.preview_material_resource)
+	_set_project_setting(KEY_GENERAL_PLANE_MATERIAL, settings.plane_material_resource)
 	_set_project_setting(KEY_ASSET_LIBRARY_PATH, settings.asset_library_path)
+
 	settings_changed.emit(get_settings())
 
 
@@ -87,19 +103,21 @@ func get_settings() -> AssetPlacerSettings:
 				storage_key, settings.bindings[binding]
 			)
 
+	settings.transform_step = _get_editor_setting(KEY_TRANSFORM_STEP, settings.transform_step)
+	settings.rotation_step = _get_editor_setting(KEY_ROTATION_STEP, settings.rotation_step)
+	settings.ui_scale = _get_editor_setting(KEY_UI_SCALE, settings.ui_scale)
+	settings.update_channel = _get_editor_setting(KEY_UPDATE_CHANNEL, settings.update_channel)
+
 	settings.preview_material_resource = _get_project_setting(
 		KEY_GENERAL_PREVIEW_MATERIAL, settings.preview_material_resource
 	)
 	settings.plane_material_resource = _get_project_setting(
 		KEY_GENERAL_PLANE_MATERIAL, settings.plane_material_resource
 	)
-	settings.transform_step = _get_editor_setting(KEY_TRANSFORM_STEP, settings.transform_step)
-	settings.rotation_step = _get_editor_setting(KEY_ROTATION_STEP, settings.rotation_step)
-	settings.ui_scale = _get_editor_setting(KEY_UI_SCALE, settings.ui_scale)
-	settings.update_channel = _get_editor_setting(KEY_UPDATE_CHANNEL, settings.update_channel)
 	settings.asset_library_path = _get_project_setting(
 		KEY_ASSET_LIBRARY_PATH, settings.asset_library_path
 	)
+
 	return settings
 
 
@@ -118,6 +136,10 @@ func _get_binding_settings(key: String, default: APInputOption) -> APInputOption
 
 func _set_project_setting(key: String, value: Variant):
 	ProjectSettings.set_setting(KEY_BASE % key, value)
+
+
+func _set_project_setting_default(key: String, value: Variant):
+	ProjectSettings.set_initial_value(KEY_BASE % key, value)
 
 
 func _get_project_setting(key: String, default: Variant):

--- a/addons/asset_placer/ui/settings/settings_panel.gd
+++ b/addons/asset_placer/ui/settings/settings_panel.gd
@@ -119,10 +119,15 @@ func _show_preview_material_picker():
 
 
 func _show_asset_library_picker():
-	var library_picker = EditorFileDialog.new()
+	var library_picker := EditorFileDialog.new()
+	# Only supported in 4.6+
+	if library_picker.get("overwrite_warning_enabled") != null:
+		library_picker.overwrite_warning_enabled = false
+
 	library_picker.file_mode = EditorFileDialog.FILE_MODE_SAVE_FILE
 	library_picker.access = EditorFileDialog.ACCESS_RESOURCES
-	library_picker.overwrite_warning_enabled = false
 	library_picker.add_filter("*.json", "Asset Library")
+	library_picker.title = "Choose where to save the AssetLibrary"
+	library_picker.ok_button_text = "Choose path"
 	library_picker.file_selected.connect(_presenter.set_asset_library_path)
 	EditorInterface.popup_dialog_centered(library_picker, Vector2i(720, 500))

--- a/addons/asset_placer/ui/settings/settings_panel.gd
+++ b/addons/asset_placer/ui/settings/settings_panel.gd
@@ -2,39 +2,58 @@
 extends Control
 
 var _presenter: SettingsPresenter = SettingsPresenter.new()
-@onready var keybinding_option_rotate = %KeybindingOptionRotate
-@onready var keybinding_option_scale = %KeybindingOptionScale
-@onready var keybinding_option_translate = %KeybindingOptionTranslate
-@onready var keybinding_option_grid_snap = %KeybindingOptionGridSnap
 @onready var reset_button: Button = %ResetButton
 
-@onready var material_picker_button = %MaterialPickerButton
-@onready var material_clear_button = %MaterialClearButton
+@onready var asset_library_button: Button = %AssetLibraryButton
+@onready var material_picker_button: Button = %MaterialPickerButton
+@onready var material_clear_button: Button = %MaterialClearButton
 @onready var plane_material_picker_button: Button = %PlaneMaterialPickerButton
-@onready var keybinding_option_in_place_transform = %KeybindingOptionInPlaceTransform
+
 @onready var trasform_step_spin_box: SpinBox = %TrasformStepSpinBox
 @onready var rotation_step_spin_box: SpinBox = %RotationStepSpinBox
 @onready var ui_scale_h_slider: HSlider = %UIScaleHSlider
 @onready var slider_value = %SliderValue
+
+@onready var update_channel_option_button: OptionButton = %UpdateChannelOptionButton
+@onready var update_channel_info_button: Button = %UpdateChannelInfoButton
+
+@onready var keybinding_option_rotate = %KeybindingOptionRotate
+@onready var keybinding_option_scale = %KeybindingOptionScale
+@onready var keybinding_option_translate = %KeybindingOptionTranslate
+@onready var keybinding_option_grid_snap = %KeybindingOptionGridSnap
+@onready var keybinding_option_in_place_transform = %KeybindingOptionInPlaceTransform
 @onready var keybinding_option_positive_transform = %KeybindingOptionPositiveTransform
 @onready var keybinding_option_negative_transform = %KeybindingOptionNegativeTransform
 @onready var keybinding_option_axis_x = %KeybindingOptionAxisX
 @onready var keybinding_option_axis_y = %KeybindingOptionAxisY
 @onready var keybinding_option_axis_z = %KeybindingOptionAxisZ
 @onready var keybinding_option_plane_mode = %KeybindingOptionPlaneMode
-@onready var update_channel_option_button: OptionButton = %UpdateChannelOptionButton
-@onready var update_channel_info_button: Button = %UpdateChannelInfoButton
 
 
 func _ready():
+	_presenter.show_settings.connect(_show_settings)
+	reset_button.pressed.connect(_presenter.reset_to_defaults)
+
+	asset_library_button.pressed.connect(_show_asset_library_picker)
+	material_clear_button.pressed.connect(_presenter.clear_preivew_material)
+	material_picker_button.pressed.connect(_show_preview_material_picker)
+	plane_material_picker_button.pressed.connect(
+		func(): EditorInterface.popup_quick_open(_presenter.set_plane_material, ["BaseMaterial3D"])
+	)
+
 	ui_scale_h_slider.drag_ended.connect(
 		func(changed): _presenter.set_ui_scale(ui_scale_h_slider.value)
 	)
 	ui_scale_h_slider.value_changed.connect(func(value): slider_value.text = str(value))
 	trasform_step_spin_box.value_changed.connect(_presenter.set_default_transform_step)
 	rotation_step_spin_box.value_changed.connect(_presenter.set_rotation_step)
-	_presenter.show_settings.connect(_show_settings)
+
 	update_channel_option_button.item_selected.connect(_presenter.set_update_channel)
+	update_channel_info_button.pressed.connect(
+		func():
+			OS.shell_open("https://levinzonr.github.io/godot-asset-placer/development-lifecycle/")
+	)
+
 	keybinding_option_rotate.keybind_changed.connect(
 		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.Rotate, key)
 	)
@@ -72,56 +91,51 @@ func _ready():
 	keybinding_option_axis_z.keybind_changed.connect(
 		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.ToggleAxisZ, key)
 	)
-	reset_button.pressed.connect(_presenter.reset_to_defaults)
-	material_clear_button.pressed.connect(_presenter.clear_preivew_material)
-	material_picker_button.pressed.connect(_show_preview_material_picker)
 
-	update_channel_info_button.pressed.connect(
-		func():
-			OS.shell_open("https://levinzonr.github.io/godot-asset-placer/development-lifecycle/")
-	)
-
-	plane_material_picker_button.pressed.connect(
-		func(): EditorInterface.popup_quick_open(_presenter.set_plane_material, ["BaseMaterial3D"])
-	)
 	_presenter.ready()
 
 
 func _show_settings(setting: AssetPlacerSettings):
-	slider_value.text = str(setting.ui_scale)
-	ui_scale_h_slider.set_value_no_signal(setting.ui_scale)
-	trasform_step_spin_box.set_value_no_signal(setting.transform_step)
-	rotation_step_spin_box.set_value_no_signal(setting.rotation_step)
-	keybinding_option_rotate.set_keybind(setting.bindings[AssetPlacerSettings.Bindings.Rotate])
-	keybinding_option_translate.set_keybind(
-		setting.bindings[AssetPlacerSettings.Bindings.Translate]
-	)
-	keybinding_option_scale.set_keybind(setting.bindings[AssetPlacerSettings.Bindings.Scale])
-	keybinding_option_grid_snap.set_keybind(
-		setting.bindings[AssetPlacerSettings.Bindings.GridSnapping]
-	)
-	keybinding_option_in_place_transform.set_keybind(
-		setting.bindings[AssetPlacerSettings.Bindings.InPlaceTransform]
-	)
-	keybinding_option_negative_transform.set_keybind(
-		setting.bindings[AssetPlacerSettings.Bindings.TransformNegative]
-	)
-	keybinding_option_positive_transform.set_keybind(
-		setting.bindings[AssetPlacerSettings.Bindings.TransformPositive]
-	)
-	keybinding_option_axis_x.set_keybind(setting.bindings[AssetPlacerSettings.Bindings.ToggleAxisX])
-	keybinding_option_axis_y.set_keybind(setting.bindings[AssetPlacerSettings.Bindings.ToggleAxisY])
-	keybinding_option_axis_z.set_keybind(setting.bindings[AssetPlacerSettings.Bindings.ToggleAxisZ])
-	keybinding_option_plane_mode.set_keybind(
-		setting.bindings[AssetPlacerSettings.Bindings.TogglePlaneMode]
-	)
-	update_channel_option_button.select(setting.update_channel)
+	asset_library_button.text = setting.asset_library_path
+	asset_library_button.tooltip_text = setting.asset_library_path
+
 	plane_material_picker_button.text = setting.plane_material_resource.get_file()
 	if setting.preview_material_resource.is_empty():
 		material_picker_button.text = "No Preview Material"
 	else:
 		material_picker_button.text = setting.preview_material_resource.get_file()
 
+	slider_value.text = str(setting.ui_scale)
+	ui_scale_h_slider.set_value_no_signal(setting.ui_scale)
+	trasform_step_spin_box.set_value_no_signal(setting.transform_step)
+	rotation_step_spin_box.set_value_no_signal(setting.rotation_step)
+
+	update_channel_option_button.select(setting.update_channel)
+
+	var Bindings := AssetPlacerSettings.Bindings
+	var bindings := setting.bindings
+	keybinding_option_rotate.set_keybind(bindings[AssetPlacerSettings.Bindings.Rotate])
+	keybinding_option_translate.set_keybind(bindings[Bindings.Translate])
+	keybinding_option_scale.set_keybind(bindings[Bindings.Scale])
+	keybinding_option_grid_snap.set_keybind(bindings[Bindings.GridSnapping])
+	keybinding_option_in_place_transform.set_keybind(bindings[Bindings.InPlaceTransform])
+	keybinding_option_negative_transform.set_keybind(bindings[Bindings.TransformNegative])
+	keybinding_option_positive_transform.set_keybind(bindings[Bindings.TransformPositive])
+	keybinding_option_axis_x.set_keybind(bindings[Bindings.ToggleAxisX])
+	keybinding_option_axis_y.set_keybind(bindings[Bindings.ToggleAxisY])
+	keybinding_option_axis_z.set_keybind(bindings[Bindings.ToggleAxisZ])
+	keybinding_option_plane_mode.set_keybind(bindings[Bindings.TogglePlaneMode])
+
 
 func _show_preview_material_picker():
 	EditorInterface.popup_quick_open(_presenter.set_preview_material, ["BaseMaterial3D"])
+
+
+func _show_asset_library_picker():
+	var library_picker = EditorFileDialog.new()
+	library_picker.file_mode = EditorFileDialog.FILE_MODE_SAVE_FILE
+	library_picker.access = EditorFileDialog.ACCESS_RESOURCES
+	library_picker.overwrite_warning_enabled = false
+	library_picker.add_filter("*.json", "Asset Library")
+	library_picker.file_selected.connect(_presenter.set_asset_library_path)
+	EditorInterface.popup_dialog_centered(library_picker, Vector2i(720, 500))

--- a/addons/asset_placer/ui/settings/settings_panel.gd
+++ b/addons/asset_placer/ui/settings/settings_panel.gd
@@ -5,6 +5,7 @@ var _presenter: SettingsPresenter = SettingsPresenter.new()
 @onready var reset_button: Button = %ResetButton
 
 @onready var asset_library_button: Button = %AssetLibraryButton
+@onready var reset_asset_library_button: Button = %ResetAssetLibraryButton
 @onready var material_picker_button: Button = %MaterialPickerButton
 @onready var material_clear_button: Button = %MaterialClearButton
 @onready var plane_material_picker_button: Button = %PlaneMaterialPickerButton
@@ -37,6 +38,9 @@ func _ready():
 	reset_button.pressed.connect(_presenter.reset_to_defaults)
 
 	asset_library_button.pressed.connect(_show_asset_library_picker)
+	reset_asset_library_button.pressed.connect(
+		_presenter.set_asset_library_path.bind(AssetPlacerSettings.DEFAULT_ASSET_LIBRARY_PATH)
+	)
 	material_clear_button.pressed.connect(_presenter.clear_preivew_material)
 	material_picker_button.pressed.connect(_show_preview_material_picker)
 	plane_material_picker_button.pressed.connect(
@@ -78,6 +82,10 @@ func _ready():
 func _show_settings(setting: AssetPlacerSettings):
 	asset_library_button.text = setting.asset_library_path
 	asset_library_button.tooltip_text = setting.asset_library_path
+	if setting.asset_library_path == setting.DEFAULT_ASSET_LIBRARY_PATH:
+		reset_asset_library_button.hide()
+	else:
+		reset_asset_library_button.show()
 
 	plane_material_picker_button.text = setting.plane_material_resource.get_file()
 	if setting.preview_material_resource.is_empty():

--- a/addons/asset_placer/ui/settings/settings_panel.gd
+++ b/addons/asset_placer/ui/settings/settings_panel.gd
@@ -17,17 +17,19 @@ var _presenter: SettingsPresenter = SettingsPresenter.new()
 @onready var update_channel_option_button: OptionButton = %UpdateChannelOptionButton
 @onready var update_channel_info_button: Button = %UpdateChannelInfoButton
 
-@onready var keybinding_option_rotate = %KeybindingOptionRotate
-@onready var keybinding_option_scale = %KeybindingOptionScale
-@onready var keybinding_option_translate = %KeybindingOptionTranslate
-@onready var keybinding_option_grid_snap = %KeybindingOptionGridSnap
-@onready var keybinding_option_in_place_transform = %KeybindingOptionInPlaceTransform
-@onready var keybinding_option_positive_transform = %KeybindingOptionPositiveTransform
-@onready var keybinding_option_negative_transform = %KeybindingOptionNegativeTransform
-@onready var keybinding_option_axis_x = %KeybindingOptionAxisX
-@onready var keybinding_option_axis_y = %KeybindingOptionAxisY
-@onready var keybinding_option_axis_z = %KeybindingOptionAxisZ
-@onready var keybinding_option_plane_mode = %KeybindingOptionPlaneMode
+# Keybinds
+
+@onready var kb_rotate = %KeybindingOptionRotate
+@onready var kb_scale = %KeybindingOptionScale
+@onready var kb_translate = %KeybindingOptionTranslate
+@onready var kb_grid_snap = %KeybindingOptionGridSnap
+@onready var kb_in_place_transform = %KeybindingOptionInPlaceTransform
+@onready var kb_positive_transform = %KeybindingOptionPositiveTransform
+@onready var kb_negative_transform = %KeybindingOptionNegativeTransform
+@onready var kb_axis_x = %KeybindingOptionAxisX
+@onready var kb_axis_y = %KeybindingOptionAxisY
+@onready var kb_axis_z = %KeybindingOptionAxisZ
+@onready var kb_plane_mode = %KeybindingOptionPlaneMode
 
 
 func _ready():
@@ -54,43 +56,21 @@ func _ready():
 			OS.shell_open("https://levinzonr.github.io/godot-asset-placer/development-lifecycle/")
 	)
 
-	keybinding_option_rotate.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.Rotate, key)
-	)
+	var Bindings := AssetPlacerSettings.Bindings
+	var set_binding := _presenter.set_binding
 
-	keybinding_option_positive_transform.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.TransformPositive, key)
-	)
+	kb_rotate.keybind_changed.connect(set_binding.bind(Bindings.Rotate))
+	kb_scale.keybind_changed.connect(set_binding.bind(Bindings.Scale))
+	kb_translate.keybind_changed.connect(set_binding.bind(Bindings.Translate))
+	kb_grid_snap.keybind_changed.connect(set_binding.bind(Bindings.GridSnapping))
 
-	keybinding_option_translate.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.Translate, key)
-	)
-
-	keybinding_option_plane_mode.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.TogglePlaneMode, key)
-	)
-
-	keybinding_option_negative_transform.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.TransformNegative, key)
-	)
-	keybinding_option_scale.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.Scale, key)
-	)
-	keybinding_option_in_place_transform.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.InPlaceTransform, key)
-	)
-	keybinding_option_grid_snap.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.GridSnapping, key)
-	)
-	keybinding_option_axis_x.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.ToggleAxisX, key)
-	)
-	keybinding_option_axis_y.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.ToggleAxisY, key)
-	)
-	keybinding_option_axis_z.keybind_changed.connect(
-		func(key): _presenter.set_binding(AssetPlacerSettings.Bindings.ToggleAxisZ, key)
-	)
+	kb_positive_transform.keybind_changed.connect(set_binding.bind(Bindings.TransformPositive))
+	kb_negative_transform.keybind_changed.connect(set_binding.bind(Bindings.TransformNegative))
+	kb_in_place_transform.keybind_changed.connect(set_binding.bind(Bindings.InPlaceTransform))
+	kb_axis_x.keybind_changed.connect(set_binding.bind(Bindings.ToggleAxisX))
+	kb_axis_y.keybind_changed.connect(set_binding.bind(Bindings.ToggleAxisY))
+	kb_axis_z.keybind_changed.connect(set_binding.bind(Bindings.ToggleAxisZ))
+	kb_plane_mode.keybind_changed.connect(set_binding.bind(Bindings.TogglePlaneMode))
 
 	_presenter.ready()
 
@@ -114,17 +94,17 @@ func _show_settings(setting: AssetPlacerSettings):
 
 	var Bindings := AssetPlacerSettings.Bindings
 	var bindings := setting.bindings
-	keybinding_option_rotate.set_keybind(bindings[AssetPlacerSettings.Bindings.Rotate])
-	keybinding_option_translate.set_keybind(bindings[Bindings.Translate])
-	keybinding_option_scale.set_keybind(bindings[Bindings.Scale])
-	keybinding_option_grid_snap.set_keybind(bindings[Bindings.GridSnapping])
-	keybinding_option_in_place_transform.set_keybind(bindings[Bindings.InPlaceTransform])
-	keybinding_option_negative_transform.set_keybind(bindings[Bindings.TransformNegative])
-	keybinding_option_positive_transform.set_keybind(bindings[Bindings.TransformPositive])
-	keybinding_option_axis_x.set_keybind(bindings[Bindings.ToggleAxisX])
-	keybinding_option_axis_y.set_keybind(bindings[Bindings.ToggleAxisY])
-	keybinding_option_axis_z.set_keybind(bindings[Bindings.ToggleAxisZ])
-	keybinding_option_plane_mode.set_keybind(bindings[Bindings.TogglePlaneMode])
+	kb_rotate.set_keybind(bindings[AssetPlacerSettings.Bindings.Rotate])
+	kb_translate.set_keybind(bindings[Bindings.Translate])
+	kb_scale.set_keybind(bindings[Bindings.Scale])
+	kb_grid_snap.set_keybind(bindings[Bindings.GridSnapping])
+	kb_in_place_transform.set_keybind(bindings[Bindings.InPlaceTransform])
+	kb_negative_transform.set_keybind(bindings[Bindings.TransformNegative])
+	kb_positive_transform.set_keybind(bindings[Bindings.TransformPositive])
+	kb_axis_x.set_keybind(bindings[Bindings.ToggleAxisX])
+	kb_axis_y.set_keybind(bindings[Bindings.ToggleAxisY])
+	kb_axis_z.set_keybind(bindings[Bindings.ToggleAxisZ])
+	kb_plane_mode.set_keybind(bindings[Bindings.TogglePlaneMode])
 
 
 func _show_preview_material_picker():

--- a/addons/asset_placer/ui/settings/settings_panel.gd
+++ b/addons/asset_placer/ui/settings/settings_panel.gd
@@ -60,21 +60,21 @@ func _ready():
 			OS.shell_open("https://levinzonr.github.io/godot-asset-placer/development-lifecycle/")
 	)
 
-	var Bindings := AssetPlacerSettings.Bindings
+	var bindings := AssetPlacerSettings.Bindings
 	var set_binding := _presenter.set_binding
 
-	kb_rotate.keybind_changed.connect(set_binding.bind(Bindings.Rotate))
-	kb_scale.keybind_changed.connect(set_binding.bind(Bindings.Scale))
-	kb_translate.keybind_changed.connect(set_binding.bind(Bindings.Translate))
-	kb_grid_snap.keybind_changed.connect(set_binding.bind(Bindings.GridSnapping))
+	kb_rotate.keybind_changed.connect(set_binding.bind(bindings.Rotate))
+	kb_scale.keybind_changed.connect(set_binding.bind(bindings.Scale))
+	kb_translate.keybind_changed.connect(set_binding.bind(bindings.Translate))
+	kb_grid_snap.keybind_changed.connect(set_binding.bind(bindings.GridSnapping))
 
-	kb_positive_transform.keybind_changed.connect(set_binding.bind(Bindings.TransformPositive))
-	kb_negative_transform.keybind_changed.connect(set_binding.bind(Bindings.TransformNegative))
-	kb_in_place_transform.keybind_changed.connect(set_binding.bind(Bindings.InPlaceTransform))
-	kb_axis_x.keybind_changed.connect(set_binding.bind(Bindings.ToggleAxisX))
-	kb_axis_y.keybind_changed.connect(set_binding.bind(Bindings.ToggleAxisY))
-	kb_axis_z.keybind_changed.connect(set_binding.bind(Bindings.ToggleAxisZ))
-	kb_plane_mode.keybind_changed.connect(set_binding.bind(Bindings.TogglePlaneMode))
+	kb_positive_transform.keybind_changed.connect(set_binding.bind(bindings.TransformPositive))
+	kb_negative_transform.keybind_changed.connect(set_binding.bind(bindings.TransformNegative))
+	kb_in_place_transform.keybind_changed.connect(set_binding.bind(bindings.InPlaceTransform))
+	kb_axis_x.keybind_changed.connect(set_binding.bind(bindings.ToggleAxisX))
+	kb_axis_y.keybind_changed.connect(set_binding.bind(bindings.ToggleAxisY))
+	kb_axis_z.keybind_changed.connect(set_binding.bind(bindings.ToggleAxisZ))
+	kb_plane_mode.keybind_changed.connect(set_binding.bind(bindings.TogglePlaneMode))
 
 	_presenter.ready()
 
@@ -100,19 +100,18 @@ func _show_settings(setting: AssetPlacerSettings):
 
 	update_channel_option_button.select(setting.update_channel)
 
-	var Bindings := AssetPlacerSettings.Bindings
-	var bindings := setting.bindings
-	kb_rotate.set_keybind(bindings[AssetPlacerSettings.Bindings.Rotate])
-	kb_translate.set_keybind(bindings[Bindings.Translate])
-	kb_scale.set_keybind(bindings[Bindings.Scale])
-	kb_grid_snap.set_keybind(bindings[Bindings.GridSnapping])
-	kb_in_place_transform.set_keybind(bindings[Bindings.InPlaceTransform])
-	kb_negative_transform.set_keybind(bindings[Bindings.TransformNegative])
-	kb_positive_transform.set_keybind(bindings[Bindings.TransformPositive])
-	kb_axis_x.set_keybind(bindings[Bindings.ToggleAxisX])
-	kb_axis_y.set_keybind(bindings[Bindings.ToggleAxisY])
-	kb_axis_z.set_keybind(bindings[Bindings.ToggleAxisZ])
-	kb_plane_mode.set_keybind(bindings[Bindings.TogglePlaneMode])
+	var bindings := AssetPlacerSettings.Bindings
+	kb_rotate.set_keybind(setting.bindings[bindings.Rotate])
+	kb_translate.set_keybind(setting.bindings[bindings.Translate])
+	kb_scale.set_keybind(setting.bindings[bindings.Scale])
+	kb_grid_snap.set_keybind(setting.bindings[bindings.GridSnapping])
+	kb_in_place_transform.set_keybind(setting.bindings[bindings.InPlaceTransform])
+	kb_negative_transform.set_keybind(setting.bindings[bindings.TransformNegative])
+	kb_positive_transform.set_keybind(setting.bindings[bindings.TransformPositive])
+	kb_axis_x.set_keybind(setting.bindings[bindings.ToggleAxisX])
+	kb_axis_y.set_keybind(setting.bindings[bindings.ToggleAxisY])
+	kb_axis_z.set_keybind(setting.bindings[bindings.ToggleAxisZ])
+	kb_plane_mode.set_keybind(setting.bindings[bindings.TogglePlaneMode])
 
 
 func _show_preview_material_picker():

--- a/addons/asset_placer/ui/settings/settings_panel.tscn
+++ b/addons/asset_placer/ui/settings/settings_panel.tscn
@@ -21,6 +21,13 @@ script = ExtResource("1_si2q2")
 icon_name = &"Tools"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
+[sub_resource type="Texture2D" id="Texture2D_xga4m"]
+resource_local_to_scene = false
+resource_name = ""
+script = ExtResource("1_si2q2")
+icon_name = &"Reload"
+metadata/_custom_type_script = "uid://dmicn3kmr620j"
+
 [sub_resource type="Texture2D" id="Texture2D_y61cc"]
 resource_local_to_scene = false
 resource_name = ""
@@ -113,11 +120,23 @@ layout_mode = 2
 layout_mode = 2
 text = "Asset Library Save Path"
 
+[node name="ResetAssetLibraryButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer6" unique_id=2032001974]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(33, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Reset to default"
+icon = SubResource("Texture2D_xga4m")
+icon_alignment = 1
+expand_icon = true
+
 [node name="AssetLibraryButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer6" unique_id=103615135]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 size_flags_horizontal = 10
+tooltip_text = "user://asset_library.json"
+text = "user://asset_library.json"
 text_overrun_behavior = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=1178045438]

--- a/addons/asset_placer/ui/settings/settings_panel.tscn
+++ b/addons/asset_placer/ui/settings/settings_panel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://ckokuu85fua3"]
+[gd_scene format=3 uid="uid://ckokuu85fua3"]
 
 [ext_resource type="Script" uid="uid://ckohy5300ciba" path="res://addons/asset_placer/ui/settings/settings_panel.gd" id="1_cqn4c"]
 [ext_resource type="PackedScene" uid="uid://bjgh4jo3pc65i" path="res://addons/asset_placer/ui/settings/components/keybinding_option.tscn" id="1_gi0tg"]
@@ -42,7 +42,7 @@ script = ExtResource("1_si2q2")
 icon_name = &"KeyboardPhysical"
 metadata/_custom_type_script = "uid://dmicn3kmr620j"
 
-[node name="SettingsPanel" type="Control"]
+[node name="SettingsPanel" type="Control" unique_id=126007270]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -51,7 +51,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_cqn4c")
 
-[node name="Panel" type="Panel" parent="."]
+[node name="Panel" type="Panel" parent="." unique_id=356747440]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -59,7 +59,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+[node name="MarginContainer" type="MarginContainer" parent="Panel" unique_id=898713020]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -71,14 +71,14 @@ theme_override_constants/margin_top = 16
 theme_override_constants/margin_right = 16
 theme_override_constants/margin_bottom = 16
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer" unique_id=1499630830]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer" unique_id=1874520967]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ResetButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer"]
+[node name="ResetButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer" unique_id=582147653]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
@@ -86,62 +86,76 @@ theme_override_styles/normal = SubResource("StyleBoxEmpty_cqn4c")
 text = "Reset To Defaults"
 icon = SubResource("Texture2D_l6bix")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer" unique_id=1100562439]
 layout_mode = 2
 theme_override_constants/separation = 32
 
-[node name="General" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="General" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1401066908]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=1535153568]
 layout_mode = 2
 
-[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer2"]
+[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer2" unique_id=742817186]
 layout_mode = 2
 texture = SubResource("Texture2D_a1e85")
 stretch_mode = 5
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer2"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer2" unique_id=1294546808]
 layout_mode = 2
 text = "Settings"
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="HBoxContainer6" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=117105376]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer3"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer6" unique_id=653223322]
+layout_mode = 2
+text = "Asset Library Save Path"
+
+[node name="AssetLibraryButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer6" unique_id=103615135]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+text_overrun_behavior = 3
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=1178045438]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer3" unique_id=687410114]
 layout_mode = 2
 text = "Transform Step (Scale, Translate)"
 
-[node name="TrasformStepSpinBox" type="SpinBox" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer3"]
+[node name="TrasformStepSpinBox" type="SpinBox" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer3" unique_id=1812298941]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
 step = 0.01
 value = 0.1
 
-[node name="HBoxContainer4" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="HBoxContainer4" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=938920544]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer4"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer4" unique_id=1343198212]
 layout_mode = 2
 text = "Rotation Step (Degrees)"
 
-[node name="RotationStepSpinBox" type="SpinBox" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer4"]
+[node name="RotationStepSpinBox" type="SpinBox" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer4" unique_id=1515420082]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
 max_value = 360.0
 value = 5.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=1123812084]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer" unique_id=1921343675]
 layout_mode = 2
 text = "Preview Material Resource"
 
-[node name="MaterialPickerButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer"]
+[node name="MaterialPickerButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer" unique_id=1303403192]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
@@ -150,40 +164,40 @@ alignment = 2
 autowrap_trim_flags = 0
 icon_alignment = 2
 
-[node name="MaterialClearButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer"]
+[node name="MaterialClearButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer" unique_id=420008564]
 unique_name_in_owner = true
 layout_mode = 2
 icon = SubResource("Texture2D_y61cc")
 
-[node name="PlaneMaterialOption" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="PlaneMaterialOption" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=82083214]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/PlaneMaterialOption"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/PlaneMaterialOption" unique_id=21734961]
 layout_mode = 2
 text = "Plane Mode Material Resource"
 
-[node name="PlaneMaterialPickerButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/PlaneMaterialOption"]
+[node name="PlaneMaterialPickerButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/PlaneMaterialOption" unique_id=1330310838]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
 text = "plane_preview_material.tres"
 alignment = 2
 
-[node name="HBoxContainer5" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="HBoxContainer5" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=1075296859]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer5"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer5" unique_id=1879340334]
 layout_mode = 2
 text = "Thumbnails UI Scale"
 
-[node name="SliderValue" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer5"]
+[node name="SliderValue" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer5" unique_id=584792401]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-text = "0.8"
+text = "1.0"
 horizontal_alignment = 2
 
-[node name="UIScaleHSlider" type="HSlider" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer5"]
+[node name="UIScaleHSlider" type="HSlider" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/HBoxContainer5" unique_id=1293124067]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -191,27 +205,27 @@ size_flags_vertical = 1
 min_value = 0.2
 max_value = 2.0
 step = 0.1
-value = 0.8
+value = 1.0
 ticks_position = 3
 
-[node name="Spacing" type="Control" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="Spacing" type="Control" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=653626810]
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
 
-[node name="UpdateChannelContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General"]
+[node name="UpdateChannelContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General" unique_id=1499912835]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/UpdateChannelContainer"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/UpdateChannelContainer" unique_id=1799532065]
 layout_mode = 2
 text = "Plugin Update Channel"
 
-[node name="UpdateChannelInfoButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/UpdateChannelContainer"]
+[node name="UpdateChannelInfoButton" type="Button" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/UpdateChannelContainer" unique_id=1662314607]
 unique_name_in_owner = true
 layout_mode = 2
 icon = SubResource("Texture2D_altf5")
 flat = true
 
-[node name="UpdateChannelOptionButton" type="OptionButton" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/UpdateChannelContainer"]
+[node name="UpdateChannelOptionButton" type="OptionButton" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/General/UpdateChannelContainer" unique_id=1908545530]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
@@ -225,78 +239,78 @@ popup/item_1/id = 1
 popup/item_2/text = "Alpha"
 popup/item_2/id = 2
 
-[node name="KeyBindings" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="KeyBindings" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1876461377]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings" unique_id=520985477]
 layout_mode = 2
 
-[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/HBoxContainer"]
+[node name="TextureRect" type="TextureRect" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/HBoxContainer" unique_id=1615448721]
 layout_mode = 2
 texture = SubResource("Texture2D_cqn4c")
 stretch_mode = 5
 
-[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/HBoxContainer"]
+[node name="Label" type="Label" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/HBoxContainer" unique_id=155629514]
 layout_mode = 2
 text = "Key Bindings"
 
-[node name="KeyBindingsOptions" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings"]
+[node name="KeyBindingsOptions" type="VBoxContainer" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings" unique_id=577854951]
 layout_mode = 2
 script = ExtResource("3_l6bix")
 
-[node name="KeybindingOptionRotate" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionRotate" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=1033935065 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Rotate Asset"
 
-[node name="KeybindingOptionScale" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionScale" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=182784807 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Scale Asset"
 
-[node name="KeybindingOptionTranslate" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionTranslate" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=612690937 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Translate Asset / Plane Placement"
 
-[node name="KeybindingOptionGridSnap" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionGridSnap" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=303777703 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Grid Snapping "
 
-[node name="KeybindingOptionPlaneMode" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionPlaneMode" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=2002350479 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Toggle Plane Mode"
 
-[node name="KeybindingOptionInPlaceTransform" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionInPlaceTransform" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=223925137 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 allow_mouse_buttons = true
 label = "In-Place Transform Mode "
 
-[node name="KeybindingOptionPositiveTransform" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionPositiveTransform" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=1164883150 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Apply Positive Transform "
 
-[node name="KeybindingOptionNegativeTransform" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionNegativeTransform" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=226098419 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Apply Negative Transform "
 
-[node name="KeybindingOptionAxisX" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionAxisX" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=1393918530 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Toggle X Axis"
 
-[node name="KeybindingOptionAxisY" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionAxisY" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=1456901673 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Toggle Y Axis"
 
-[node name="KeybindingOptionAxisZ" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" instance=ExtResource("1_gi0tg")]
+[node name="KeybindingOptionAxisZ" parent="Panel/MarginContainer/ScrollContainer/VBoxContainer/HBoxContainer/KeyBindings/KeyBindingsOptions" unique_id=1973765067 instance=ExtResource("1_gi0tg")]
 unique_name_in_owner = true
 layout_mode = 2
 label = "Toggle Z Axis"

--- a/addons/asset_placer/ui/settings/settings_presenter.gd
+++ b/addons/asset_placer/ui/settings/settings_presenter.gd
@@ -22,6 +22,14 @@ func reset_to_defaults():
 	_repository.set_settings(AssetPlacerSettings.default())
 
 
+func set_asset_library_path(path: String):
+	var settings = _repository.get_settings()
+	settings.asset_library_path = path
+	_repository.set_settings(settings)
+
+	AssetLibraryManager.update_save_path(path)
+
+
 func set_default_transform_step(value: float):
 	var settings = _repository.get_settings()
 	settings.transform_step = value

--- a/addons/asset_placer/ui/settings/settings_presenter.gd
+++ b/addons/asset_placer/ui/settings/settings_presenter.gd
@@ -99,7 +99,7 @@ func set_binding_in_place_transform(key: APInputOption):
 	_repository.set_settings(current)
 
 
-func set_binding(key: AssetPlacerSettings.Bindings, input: APInputOption):
+func set_binding(input: APInputOption, key: AssetPlacerSettings.Bindings):
 	var current_settings = _repository.get_settings()
 	current_settings.bindings[key] = input
 	_repository.set_settings(current_settings)

--- a/addons/asset_placer/ui/settings/settings_presenter.gd
+++ b/addons/asset_placer/ui/settings/settings_presenter.gd
@@ -28,7 +28,7 @@ func set_asset_library_path(path: String):
 	_repository.set_settings(settings)
 
 	AssetLibraryManager.update_save_path(path)
-
+	ProjectSettings.save()
 
 func set_default_transform_step(value: float):
 	var settings = _repository.get_settings()
@@ -61,6 +61,7 @@ func set_preview_material(material: String):
 	current.preview_material_resource = material
 	_repository.set_settings(current)
 
+	ProjectSettings.save()
 
 func set_plane_material(material: String):
 	if not material.is_empty():
@@ -68,6 +69,7 @@ func set_plane_material(material: String):
 		current.plane_material_resource = material
 		_repository.set_settings(current)
 
+	ProjectSettings.save()
 
 func clear_preivew_material():
 	var current = _repository.get_settings()

--- a/addons/asset_placer/ui/settings/settings_presenter.gd
+++ b/addons/asset_placer/ui/settings/settings_presenter.gd
@@ -30,6 +30,7 @@ func set_asset_library_path(path: String):
 	AssetLibraryManager.update_save_path(path)
 	ProjectSettings.save()
 
+
 func set_default_transform_step(value: float):
 	var settings = _repository.get_settings()
 	settings.transform_step = value
@@ -63,13 +64,16 @@ func set_preview_material(material: String):
 
 	ProjectSettings.save()
 
+
 func set_plane_material(material: String):
-	if not material.is_empty():
-		var current = _repository.get_settings()
-		current.plane_material_resource = material
-		_repository.set_settings(current)
+	if material.is_empty():
+		return
+	var current = _repository.get_settings()
+	current.plane_material_resource = material
+	_repository.set_settings(current)
 
 	ProjectSettings.save()
+
 
 func clear_preivew_material():
 	var current = _repository.get_settings()

--- a/project.godot
+++ b/project.godot
@@ -19,12 +19,6 @@ run/main_scene="uid://3qun24bndqll"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 
-[asset_placer]
-
-general/preview_material="res://addons/asset_placer/utils/preview_material.tres"
-general/plane_material="res://addons/asset_placer/ui/plane_preview/plane_preview_material.tres"
-general/asset_library_path="user://asset_library.json"
-
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/asset_placer/plugin.cfg")


### PR DESCRIPTION
Follow up to #76 

Adds the setting in the settings panel to change the asset library path.

Also fixed a bug where project settings weren't saved to project.godot, as well as adding default values for those settings.

Changing the asset library path is intended to let users include the library in VCS. The implementation intentionally doesn't overwrite or remove any files.

## Type of Change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?
Tested in 4.6.2-stable and 4.4.1-stable.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally in Godot
- [x] I have updated documentation if needed
- [x] I have added relevant tests if applicable
