### PR TITLE
Fix duplicate initialization of query_words

### DIFF
--- a/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
+++ b/addons/asset_placer/ui/asset_library_window/asset_library_presenter.gd
@@ -104,7 +104,6 @@ func _filter_by_collections_and_query():
 
 	var query_words := Array(_current_query.strip_edges().to_lower().split(" ", false))
 	var include_wor
-	var query_words := Array(_current_query.strip_edges().to_lower().split(" ", false))
 	var include_words: Array[String] = []
 	var exclude_words: Array[String] = []
 	for w: String in query_words:


### PR DESCRIPTION
Removed duplicate initialization of query_words array.

# Pull Request

## Description

this random syntax error was causing alot of parsing errors when installing the addon


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please specify):

## How Has This Been Tested?

 just a very small error 

## Checklist

- [ ] My code follows the existing code style and conventions
- [x] I have tested my changes locally in Godot
- [ ] I have updated documentation if needed
- [ ] I have added relevant tests if applicable

## Additional Context

Add any other context or screenshots about the PR here. This will help reviewers understand the changes better.
